### PR TITLE
Add request id to logs.

### DIFF
--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -250,8 +250,10 @@ func (s *Server) StartGRPCServer(ctx context.Context) error {
 	interceptors := []grpc.UnaryServerInterceptor{
 		// TODO: this has no test coverage!
 		util.SanitizingInterceptor(),
+		// This adds `Grpc-Metadata-Request-Id` to the
+		// response.
+		logger.RequestIDInterceptor("request-id"),
 		logger.Interceptor(s.cfg.LoggingConfig),
-		logger.RequestIDInterceptor(),
 		TokenValidationInterceptor,
 		EntityContextProjectInterceptor,
 		ProjectAuthorizationInterceptor,

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -251,6 +251,7 @@ func (s *Server) StartGRPCServer(ctx context.Context) error {
 		// TODO: this has no test coverage!
 		util.SanitizingInterceptor(),
 		logger.Interceptor(s.cfg.LoggingConfig),
+		logger.RequestIDInterceptor(),
 		TokenValidationInterceptor,
 		EntityContextProjectInterceptor,
 		ProjectAuthorizationInterceptor,

--- a/internal/logger/logging_interceptor.go
+++ b/internal/logger/logging_interceptor.go
@@ -105,42 +105,20 @@ func Interceptor(cfg config.LoggingConfig) grpc.UnaryServerInterceptor {
 
 // RequestIDInterceptor traces request ids.
 //
-// It tries to use the request id from the request context, creating a
-// new one if that is missing. It also sends back in the trailer the
-// request id, ensuring that the client receives it.
-func RequestIDInterceptor() grpc.UnaryServerInterceptor {
+// It's job is to add a request id (UUID) to the context so that all
+// subsequent logs inherit it, making it easier to track down problems
+// on a per-request basis. It also sends back it back in a header.
+func RequestIDInterceptor(headerSuffix string) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		rID := maybeGetRequestID(ctx)
+		rID := uuid.New().String()
 		ctx = zerolog.Ctx(ctx).With().Str("request_id", rID).Logger().WithContext(ctx)
 
 		resp, err := handler(ctx, req)
 
-		if err := grpc.SetTrailer(ctx, metadata.Pairs("request-id", rID)); err != nil {
+		if err := grpc.SendHeader(ctx, metadata.Pairs(headerSuffix, rID)); err != nil {
 			zerolog.Ctx(ctx).Trace().Err(err).Msg("unable to attach request id to trailer")
 		}
 
 		return resp, err
 	}
-}
-
-func maybeGetRequestID(ctx context.Context) string {
-	var rID string
-	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		if rIDs, ok := md["request-id"]; ok {
-			if len(rIDs) != 0 {
-				rID = rIDs[0]
-			}
-		}
-	}
-
-	if rID == "" {
-		return uuid.New().String()
-	}
-
-	if _, err := uuid.Parse(rID); err != nil {
-		zerolog.Ctx(ctx).Trace().Err(err).Msg("request id is not valid uuid")
-		return uuid.New().String()
-	}
-
-	return rID
 }


### PR DESCRIPTION
# Summary

This change adds a GRPC interceptor that fetches the header `Grpc-Metadata-Request-Id` and adds it to the logger. It also returns the request id to the client in the header, which is helpful for debugging.

Fixes #4611 

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [X] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual tests.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [X] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
