### PR TITLE
Fix dependabot grouping of otel dependencies.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,9 +22,9 @@ updates:
     groups:
       otel:
         patterns:
-          - "go.opentelemetry.io/otel/*"
-          - "go.opentelemetry.io/contrib/*"
-          - "github.com/signalfx/splunk-otel-go/*"
+          - "go.opentelemetry.io/otel*"
+          - "go.opentelemetry.io/contrib*"
+          - "github.com/signalfx/splunk-otel-go*"
   - package-ecosystem: "gomod"
     directory: "tools"
     schedule:


### PR DESCRIPTION
# Summary

Current dependabot configuration leaves out `.../otel` because it lacks the trailing slash.

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [X] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Dependabot config.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
