### PR TITLE
Display request ids in the CLI.

### DIFF
--- a/cmd/cli/app/root.go
+++ b/cmd/cli/app/root.go
@@ -108,6 +108,7 @@ func init() {
 		RootCmd.Printf("error: %s", err)
 		os.Exit(1)
 	}
+	RootCmd.PersistentFlags().BoolP("verbose", "v", false, "Output additional messages to STDERR")
 	viper.AutomaticEnv()
 }
 

--- a/internal/util/cli/cli.go
+++ b/internal/util/cli/cli.go
@@ -99,7 +99,7 @@ func GRPCClientWrapRunE(
 		ctx, cancel := GetAppContext(cmd.Context(), viper.GetViper())
 		defer cancel()
 
-		c, err := GrpcForCommand(viper.GetViper())
+		c, err := GrpcForCommand(cmd, viper.GetViper())
 		if err != nil {
 			return err
 		}

--- a/internal/util/cli/rpc_client.go
+++ b/internal/util/cli/rpc_client.go
@@ -34,6 +34,7 @@ import (
 	httphelper "github.com/zitadel/oidc/v3/pkg/http"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/mindersec/minder/internal/config"
 	clientconfig "github.com/mindersec/minder/internal/config/client"
@@ -52,8 +53,28 @@ var accessDeniedHtml []byte
 //go:embed html/generic_failure.html
 var genericAuthFailure []byte
 
+func requestIDInterceptor(printer func(string, ...interface{})) grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context,
+		method string,
+		req any,
+		reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		var header metadata.MD
+		opts = append(opts, grpc.Header(&header))
+		err := invoker(ctx, method, req, reply, cc, opts...)
+		if len(header.Get("request-id")) != 0 {
+			printer("Request ID: %s\n", header.Get("request-id")[0])
+		}
+		return err
+	}
+}
+
 // GrpcForCommand is a helper for getting a testing connection from cobra flags
-func GrpcForCommand(v *viper.Viper) (*grpc.ClientConn, error) {
+func GrpcForCommand(cmd *cobra.Command, v *viper.Viper) (*grpc.ClientConn, error) {
 	clientConfig, err := config.ReadConfigFromViper[clientconfig.Config](v)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read config: %w", err)
@@ -67,8 +88,21 @@ func GrpcForCommand(v *viper.Viper) (*grpc.ClientConn, error) {
 	issuerUrl := clientConfig.Identity.CLI.IssuerUrl
 	clientId := clientConfig.Identity.CLI.ClientId
 
+	opts := []grpc.DialOption{}
+	opts = append(opts, grpc.WithUserAgent(useragent.GetUserAgent()))
+
+	if viper.GetBool("verbose") {
+		opts = append(opts, grpc.WithUnaryInterceptor(requestIDInterceptor(cmd.PrintErrf)))
+	}
+
 	return util.GetGrpcConnection(
-		grpcHost, grpcPort, allowInsecure, issuerUrl, clientId, grpc.WithUserAgent(useragent.GetUserAgent()))
+		grpcHost,
+		grpcPort,
+		allowInsecure,
+		issuerUrl,
+		clientId,
+		opts...,
+	)
 }
 
 // EnsureCredentials is a PreRunE function to ensure that the user


### PR DESCRIPTION
# Summary

This change adds a `-v/--verbose` flag that causes Minder CLI to output request ids to standard error.

It's worth noticing that some commands (e.g. `minder ruletype create` and `delete`) issue multiple calls to Minder BE and thus output request ids multiple times.

Fixes #4612

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [X] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [X] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual testing.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
