### PR TITLE
Deprecate pushing a brew formula to stacklok/tap

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -79,7 +79,6 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
           WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
           VERSION: ${{ needs.ldflags_args.outputs.version }}
           COMMIT: ${{ needs.ldflags_args.outputs.commit }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,20 +41,6 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
-# This section defines how to release to homebrew.
-brews:
-  - homepage: 'https://github.com/mindersec/minder'
-    description: 'minder is the client CLI for interacting with Minder by Stacklok.'
-    directory: Formula
-    commit_author:
-      name: stacklokbot
-      email: info@stacklok.com
-    repository:
-      owner: stacklok
-      name: homebrew-tap
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    test: |
-      system "#{bin}/minder --help"
 # This section defines how to release to winget.
 winget:
   - name: minder

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Choose your preferred method to install `minder`:
 Make sure you have [Homebrew](https://brew.sh/) installed.
 
 ```bash
-brew install stacklok/tap/minder
+brew install minder
 ```
 
 ### Windows (Winget)

--- a/docs/docs/getting_started/install_cli.md
+++ b/docs/docs/getting_started/install_cli.md
@@ -16,7 +16,7 @@ You can install `minder` using one of the following methods:
 The easiest way to install `minder` for macOS systems is through [Homebrew](https://brew.sh/):
 
 ```bash
-brew install stacklok/tap/minder
+brew install minder
 ```
 
 Alternatively, you can [download a `.tar.gz` release](https://github.com/mindersec/minder/releases) and unpack it with the following:


### PR DESCRIPTION
# Summary

The following PR updates the release process so we no longer push a custom formula to `stacklok/tap`. Instead, we rely on brew's automation to catch the new release of the minder CLI and updates its entry in the `homebrew-core` repo. Currently this happens every 3 hours.

Related: https://github.com/mindersec/minder/issues/4753

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
