### PR TITLE
Revert "Temporarily remove migration check"

### DIFF
--- a/.github/workflows/migrate-touch.yml
+++ b/.github/workflows/migrate-touch.yml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright 2023 The Minder Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# This test verifies that Pull Requests don't touch the merged database migrations.
+# Folks should now only be adding new migrations to the `database/migrations/` directory.
+name: Database Migrations Untouched
+on:
+  pull_request:
+    paths:
+      - 'database/migrations/*'
+      - '.github/workflows/migrate-touch.yml'
+jobs:
+  verify-migrations:
+    name: Don't touch existing migrations
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          fetch-depth: 0
+      - name: Verify Migration Files
+        run: |
+          # Check out the base branch
+          git checkout $GITHUB_BASE_REF
+          # Get files in migration directory before our changes
+          BEFORE=$(find database/migrations/ -type f | sort)
+          echo "Files before: $BEFORE"
+
+          # Check out our changes
+          git checkout $GITHUB_SHA -- database/migrations/
+
+          # Verify that the existing migration files were not touched by the new changes
+          modified=$(git diff --name-only origin/$GITHUB_BASE_REF $GITHUB_SHA -- database/migrations/)
+          echo "Files modified: $modified"
+          for file in $modified; do
+            if [[ $BEFORE == *"$file"* ]]; then
+              echo "ERROR: $file was modified by this PR. Please only add new migrations to the database/migrations/ directory."
+              exit 1
+            fi
+          done
+        shell: bash


### PR DESCRIPTION
This reverts commit aaa57c7f5b707a003ce64aa2816dba495a89005c.

# Summary

Following up to https://github.com/mindersec/minder/pull/4764, this PR restores the migration check workflow that was temporarily removed to help merge the boilerplates.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [ ] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
