### PR TITLE
Change defaults for pull request rules

### DIFF
--- a/internal/engine/eval/trusty/config.go
+++ b/internal/engine/eval/trusty/config.go
@@ -19,7 +19,32 @@ var (
 	// SummaryScore is the score to use for the summary score
 	SummaryScore = "score"
 	// DefaultScore is the default score to use
-	DefaultScore = ""
+	DefaultScore           = ""
+	defaultAction          = pr_actions.ActionReviewPr
+	defaultEcosystemConfig = []ecosystemConfig{
+		{
+			Name:            "npm",
+			Score:           5.0,
+			Provenance:      5.0,
+			Activity:        5.0,
+			AllowMalicious:  false,
+			AllowDeprecated: false,
+		},
+		{
+			Name:            "pypi",
+			Score:           5.0,
+			Provenance:      5.0,
+			Activity:        5.0,
+			AllowDeprecated: false,
+		},
+		{
+			Name:            "go",
+			Score:           5.0,
+			Provenance:      5.0,
+			Activity:        5.0,
+			AllowDeprecated: false,
+		},
+	}
 )
 
 type ecosystemConfig struct {
@@ -50,40 +75,19 @@ type config struct {
 	EcosystemConfig []ecosystemConfig `json:"ecosystem_config" mapstructure:"ecosystem_config" validate:"required"`
 }
 
-func defaultConfig() *config {
-	return &config{
-		Action: pr_actions.ActionReviewPr,
-		EcosystemConfig: []ecosystemConfig{
-			{
-				Name:            "npm",
-				Score:           5.0,
-				Provenance:      5.0,
-				Activity:        5.0,
-				AllowMalicious:  false,
-				AllowDeprecated: false,
-			},
-			{
-				Name:            "pypi",
-				Score:           5.0,
-				Provenance:      5.0,
-				Activity:        5.0,
-				AllowDeprecated: false,
-			},
-			{
-				Name:            "go",
-				Score:           5.0,
-				Provenance:      5.0,
-				Activity:        5.0,
-				AllowDeprecated: false,
-			},
-		},
+func populateDefaultsIfEmpty(ruleCfg map[string]any) {
+	if ruleCfg["ecosystem_config"] == nil {
+		ruleCfg["ecosystem_config"] = defaultEcosystemConfig
+	} else if ecoCfg, ok := ruleCfg["ecosystem_config"].([]interface{}); ok && len(ecoCfg) == 0 {
+		ruleCfg["ecosystem_config"] = defaultEcosystemConfig
+	}
+	if ruleCfg["action"] == nil {
+		ruleCfg["action"] = defaultAction
 	}
 }
 
 func parseConfig(ruleCfg map[string]any) (*config, error) {
-	if len(ruleCfg) == 0 {
-		return defaultConfig(), nil
-	}
+	populateDefaultsIfEmpty(ruleCfg)
 
 	var conf config
 	validate := validator.New(validator.WithRequiredStructEnabled())

--- a/internal/engine/eval/trusty/trusty_test.go
+++ b/internal/engine/eval/trusty/trusty_test.go
@@ -161,7 +161,9 @@ func TestParseRuleConfig(t *testing.T) {
 		},
 		{
 			"invalid-config", map[string]any{
-				"hey": "you",
+				"ecosystem_config": []string{
+					"hey",
+				},
 			}, true,
 		},
 	} {
@@ -595,5 +597,12 @@ func TestEvaluationDetailRendering(t *testing.T) {
 			require.True(t, ok)
 			require.Equal(t, tt.details, evalErr.Details())
 		})
+	}
+}
+
+func defaultConfig() *config {
+	return &config{
+		Action:          defaultAction,
+		EcosystemConfig: defaultEcosystemConfig,
 	}
 }


### PR DESCRIPTION
# Summary

We had previously added a function that defaulted the rule configuration if it was empty, in order to make the experience smoother for the UI user.
Since then, the UI has made a change that doesn't send an empty configuration by default, and instead sets some of the fields.

This change ensures that any fields that are unset get a default value.

We should consider moving default values to the rule schema itself, and marking the field as required, but that will be done as part of a larger rule validation epic.

Fixes https://github.com/mindersec/minder-rules-and-profiles/issues/184

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
