### PR TITLE
mindev: Add new subcommand to validate ruletype updates

### DIFF
--- a/cmd/dev/app/rule_type/ruletype.go
+++ b/cmd/dev/app/rule_type/ruletype.go
@@ -15,6 +15,7 @@ func CmdRuleType() *cobra.Command {
 
 	rtCmd.AddCommand(CmdTest())
 	rtCmd.AddCommand(CmdLint())
+	rtCmd.AddCommand(CmdValidateUpdate())
 
 	return rtCmd
 }

--- a/cmd/dev/app/rule_type/validate_update.go
+++ b/cmd/dev/app/rule_type/validate_update.go
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: Copyright 2023 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package rule_type
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/mindersec/minder/internal/util/schemaupdate"
+)
+
+// CmdValidateUpdate is the command for validating an update of a rule type definition
+func CmdValidateUpdate() *cobra.Command {
+	var vuCmd = &cobra.Command{
+		Use:     "validate-update",
+		Aliases: []string{"vu"},
+		Short:   "validate an update of a rule type definition",
+		Long: `The 'ruletype validate-update' subcommand allows you to validate an update of a rule type 
+definition`,
+		RunE:         vuCmdRun,
+		SilenceUsage: true,
+	}
+	vuCmd.Flags().StringP("before", "b", "", "file to read rule type definition from")
+	vuCmd.Flags().StringP("after", "a", "", "file to read rule type definition from")
+
+	if err := vuCmd.MarkFlagRequired("before"); err != nil {
+		fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
+		os.Exit(1)
+	}
+	if err := vuCmd.MarkFlagRequired("after"); err != nil {
+		fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
+		os.Exit(1)
+	}
+
+	return vuCmd
+}
+
+func vuCmdRun(cmd *cobra.Command, _ []string) error {
+	beforePath := cmd.Flag("before").Value.String()
+	afterPath := cmd.Flag("after").Value.String()
+
+	beforeRt, err := readRuleTypeFromFile(beforePath)
+	if err != nil {
+		return fmt.Errorf("error reading rule type from %s: %w", beforePath, err)
+	}
+
+	afterRt, err := readRuleTypeFromFile(afterPath)
+	if err != nil {
+		return fmt.Errorf("error reading rule type from %s: %w", afterPath, err)
+	}
+
+	// We only validate the after rule type because the before rule type is assumed to be valid
+	if err := afterRt.Validate(); err != nil {
+		return fmt.Errorf("error validating rule type %s: %w", afterPath, err)
+	}
+
+	if beforeRt.GetName() != afterRt.GetName() {
+		return fmt.Errorf("rule type name cannot be changed")
+	}
+
+	beforeDef := beforeRt.GetDef()
+	afterDef := afterRt.GetDef()
+
+	if err := schemaupdate.ValidateSchemaUpdate(beforeDef.GetRuleSchema(), afterDef.GetRuleSchema()); err != nil {
+		return fmt.Errorf("error validating rule schema update: %w", err)
+	}
+
+	if err := schemaupdate.ValidateSchemaUpdate(beforeDef.GetParamSchema(), afterDef.GetParamSchema()); err != nil {
+		return fmt.Errorf("error validating param schema update: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Summary

`mindev ruletype validate-update` (or `mindev ruletype vu` for short)
takes two YAML files and validate if the rule type can be updated (or
not).

```
$ mindev ruletype validate-update -h
The 'ruletype validate-update' subcommand allows you to validate an update of a rule type
definition

Usage:
  mindev ruletype validate-update [flags]

Aliases:
  validate-update, vu

Flags:
  -a, --after string    file to read rule type definition from
  -b, --before string   file to read rule type definition from
  -h, --help            help for validate-update
```

If the validation succeeds, we should just get a "zero" return value.

```
$ mindev ruletype vu -b before.yaml -a after.yaml
```

If it fails, we should get the reasoning, and a non-zero return value:

```
$ mindev ruletype vu -b before.yaml -a after.yaml
Error: error validating param schema update: failed to validate properties: cannot remove properties from rule schema
Message: Error on execute
Details: error validating param schema update: failed to validate properties: cannot remove properties from rule schema
 [1] $
```

This should help us gate rule type updates in CI more easily.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
