### PR TITLE
Make `minder ruletype` `apply`/`create` smarter

### DIFF
--- a/cmd/cli/app/ruletype/common.go
+++ b/cmd/cli/app/ruletype/common.go
@@ -40,10 +40,6 @@ func execOnOneRuleType(
 
 	r := &minderv1.RuleType{}
 	if err := minderv1.ParseResource(reader, r); err != nil {
-		if minderv1.YouMayHaveTheWrongResource(err) {
-			// We'll skip the file if it's not a rule type
-			return nil
-		}
 		return fmt.Errorf("error parsing rule type: %w", err)
 	}
 
@@ -96,10 +92,6 @@ func shouldSkipFile(f string) bool {
 	ext := filepath.Ext(f)
 	switch ext {
 	case ".yaml", ".yml", ".json":
-		if cli.IsTestFile(f) {
-			// Skip test files.
-			return true
-		}
 		return false
 	default:
 		fmt.Fprintf(os.Stderr, "Skipping file %s: not a yaml or json file\n", f)

--- a/cmd/cli/app/ruletype/ruletype_apply.go
+++ b/cmd/cli/app/ruletype/ruletype_apply.go
@@ -83,13 +83,18 @@ func applyCommand(_ context.Context, cmd *cobra.Command, _ []string, conn *grpc.
 	}
 
 	for _, f := range files {
-		if shouldSkipFile(f) {
+		if shouldSkipFile(f.Path) {
 			continue
 		}
 		// cmd.Context() is the root context. We need to create a new context for each file
 		// so we can avoid the timeout.
-		if err = execOnOneRuleType(cmd.Context(), table, f, os.Stdin, project, applyFunc); err != nil {
-			return cli.MessageAndError(fmt.Sprintf("error applying rule type from %s", f), err)
+		if err = execOnOneRuleType(cmd.Context(), table, f.Path, os.Stdin, project, applyFunc); err != nil {
+			if f.Expanded && minderv1.YouMayHaveTheWrongResource(err) {
+				cmd.PrintErrf("Skipping file %s: not a rule type\n", f.Path)
+				// We'll skip the file if it's not a rule type
+				continue
+			}
+			return cli.MessageAndError(fmt.Sprintf("error applying rule type from %s", f.Path), err)
 		}
 	}
 	// Render the table

--- a/internal/util/cli/cli.go
+++ b/internal/util/cli/cli.go
@@ -233,11 +233,5 @@ func GetRelevantCLIConfigPath(v *viper.Viper) string {
 
 // IsYAMLFileAndNotATest checks if a file is a YAML file and not a test file
 func IsYAMLFileAndNotATest(path string) bool {
-	return (filepath.Ext(path) == ".yaml" || filepath.Ext(path) == ".yml") &&
-		!IsTestFile(path)
-}
-
-// IsTestFile checks if a file is a test file. Test files are YAML files ending with .test.yaml or .test.yml
-func IsTestFile(path string) bool {
-	return strings.HasSuffix(path, ".test.yaml") || strings.HasSuffix(path, ".test.yml")
+	return (filepath.Ext(path) == ".yaml" || filepath.Ext(path) == ".yml")
 }

--- a/internal/util/helpers.go
+++ b/internal/util/helpers.go
@@ -406,14 +406,23 @@ func OpenFileArg(f string, dashOpen io.Reader) (desc io.Reader, closer func(), e
 	return desc, closer, nil
 }
 
+// ExpandedFile is a struct to hold a file path and whether it was expanded
+type ExpandedFile struct {
+	Path     string
+	Expanded bool
+}
+
 // ExpandFileArgs expands a list of file arguments into a list of files.
 // If the file list contains "-" or regular files, it will leave them as-is.
 // If the file list contains directories, it will expand them into a list of files.
-func ExpandFileArgs(files []string) ([]string, error) {
-	var expandedFiles []string
+func ExpandFileArgs(files []string) ([]ExpandedFile, error) {
+	var expandedFiles []ExpandedFile
 	for _, f := range files {
 		if f == "-" {
-			expandedFiles = append(expandedFiles, f)
+			expandedFiles = append(expandedFiles, ExpandedFile{
+				Path:     f,
+				Expanded: false,
+			})
 			continue
 		}
 		f = filepath.Clean(f)
@@ -430,7 +439,10 @@ func ExpandFileArgs(files []string) ([]string, error) {
 				}
 
 				if !info.IsDir() {
-					expandedFiles = append(expandedFiles, path)
+					expandedFiles = append(expandedFiles, ExpandedFile{
+						Path:     path,
+						Expanded: true,
+					})
 				}
 
 				return nil
@@ -440,7 +452,10 @@ func ExpandFileArgs(files []string) ([]string, error) {
 			}
 		} else {
 			// add file
-			expandedFiles = append(expandedFiles, f)
+			expandedFiles = append(expandedFiles, ExpandedFile{
+				Path:     f,
+				Expanded: false,
+			})
 		}
 	}
 

--- a/pkg/api/protobuf/go/minder/v1/api.go
+++ b/pkg/api/protobuf/go/minder/v1/api.go
@@ -99,7 +99,7 @@ func ParseResource(r io.Reader, rm ResourceMeta) error {
 	}
 
 	if err := json.NewDecoder(w).Decode(rm); err != nil {
-		return fmt.Errorf("error decoding json: %w", err)
+		return errors.Join(ErrNotAResource, fmt.Errorf("error decoding resource: %w", err))
 	}
 
 	if err := Validate(rm); err != nil {


### PR DESCRIPTION
# Summary

This changes the behavior of these commands...

If we only give one file or standard input, it will actually parse
and fail if it's not a minder resource (you probably REALLY wanted
to apply that file).

If it's a directory, it'll try to be smart and apply as much as it can.

It all depends on if the file was expanded or not.

Consequently, this fixes the issue we used to have with test files in
the `minder-rules-and-profiles` repo.

Co-Authored-By: Michelangelo Mori <mmori@stacklok.com>

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
