### PR TITLE
Simplify logic for required branch parameter to gh_branch_protection

### DIFF
--- a/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect.go
+++ b/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect.go
@@ -118,7 +118,7 @@ func (r *GhBranchProtectRemediator) Do(
 	}
 
 	branch, err := util.JQReadFrom[string](ctx, ".branch", params.GetRule().Params)
-	if err != nil {
+	if err != nil && !errors.Is(err, util.ErrNoValueFound) {
 		return nil, fmt.Errorf("error reading branch from params: %w", err)
 	}
 
@@ -126,7 +126,7 @@ func (r *GhBranchProtectRemediator) Do(
 	// causes issues down the road. Besides, it does not make
 	// sense to protect what does not exist. (cit. Ozz 2024-05-27)
 	if branch == "" && repo.DefaultBranch == "" {
-		return nil, fmt.Errorf("both rule param and default branch names are empty: %w", engerrors.ErrActionSkipped)
+		return nil, fmt.Errorf("both rule param branch name and repo default branch are empty: %w", engerrors.ErrActionSkipped)
 	}
 	// This sets the branch to the default one of the repository
 	// in case no branch is configured via rule parameters.

--- a/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect.go
+++ b/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect.go
@@ -121,17 +121,17 @@ func (r *GhBranchProtectRemediator) Do(
 	if err != nil && !errors.Is(err, util.ErrNoValueFound) {
 		return nil, fmt.Errorf("error reading branch from params: %w", err)
 	}
-
-	// This check avoids passing around an empty branch name which
-	// causes issues down the road. Besides, it does not make
-	// sense to protect what does not exist. (cit. Ozz 2024-05-27)
-	if branch == "" && repo.DefaultBranch == "" {
-		return nil, fmt.Errorf("both rule param branch name and repo default branch are empty: %w", engerrors.ErrActionSkipped)
-	}
 	// This sets the branch to the default one of the repository
 	// in case no branch is configured via rule parameters.
 	if branch == "" {
 		branch = repo.DefaultBranch
+	}
+
+	// This check avoids passing around an empty branch name which
+	// causes issues down the road. Besides, it does not make
+	// sense to protect what does not exist. (cit. Ozz 2024-05-27)
+	if branch == "" {
+		return nil, fmt.Errorf("both rule param branch name and repo default branch are empty: %w", engerrors.ErrActionSkipped)
 	}
 
 	// get the current protection

--- a/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect_test.go
+++ b/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect_test.go
@@ -218,8 +218,8 @@ func TestBranchProtectionRemediate(t *testing.T) {
 			remArgs: &remediateArgs{
 				remAction: models.ActionOptOn,
 				ent: &pb.Repository{
-					Owner: repoOwner,
-					Name:  repoName,
+					Owner:         repoOwner,
+					Name:          repoName,
 					DefaultBranch: "main",
 				},
 				pol: map[string]any{


### PR DESCRIPTION
# Summary

I spent a lot of time in https://github.com/mindersec/community/pull/6/commits/728938ef8ff4c67c5bb1f4318d33f30ea3d64881 banging my head on figuring out that you need to create a `branch` param for the `gh_branch_protection` remediation.  Since the param is allowed to be `""` (at which point we use the repo's default branch), let's not require the parameter at all.

Later: we need to figure out a mechanism to flag and validate these sorts of constraints at rule type create time, rather than at rule eval time.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

I added a unit test.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
