### PR TITLE
Propagate project and entity information to rule evaluation logs

### DIFF
--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -78,12 +78,15 @@ func NewExecutor(
 // EvalEntityEvent evaluates the entity specified in the EntityInfoWrapper
 // against all relevant rules in the project hierarchy.
 func (e *executor) EvalEntityEvent(ctx context.Context, inf *entities.EntityInfoWrapper) error {
-	logger := zerolog.Ctx(ctx).Info().
+	logger := zerolog.Ctx(ctx).With().
 		Str("entity_type", inf.Type.ToString()).
 		Str("execution_id", inf.ExecutionID.String()).
 		Str("provider_id", inf.ProviderID.String()).
-		Str("project_id", inf.ProjectID.String())
-	logger.Msg("entity evaluation - started")
+		Str("project_id", inf.ProjectID.String()).
+		Logger()
+	logger.Info().Msg("entity evaluation - started")
+	// Propagate info to remaining log messages
+	ctx = logger.WithContext(ctx)
 
 	// track the time taken to evaluate each entity
 	entityStartTime := time.Now()


### PR DESCRIPTION
# Summary

Currently, mostly of the rule evaluation logs don't include information about things like `project_id` or `entity_id`, which makes it hard to find specific error logs about a particular instance.  We _do_ have a single log message that indicates that the rule evaluation is started, but then a bunch of logs happen that don't clearly link back to the `entity evaluation - started` message.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual only, sorry!

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
