### PR TITLE
Fix `mindev ruletype lint`.

### DIFF
--- a/cmd/cli/app/ruletype/ruletype_apply.go
+++ b/cmd/cli/app/ruletype/ruletype_apply.go
@@ -41,7 +41,7 @@ func applyCommand(_ context.Context, cmd *cobra.Command, _ []string, conn *grpc.
 		return cli.MessageAndError("Error validating file flag", err)
 	}
 
-	files, err := util.ExpandFileArgs(fileFlag)
+	files, err := util.ExpandFileArgs(fileFlag...)
 	if err != nil {
 		return cli.MessageAndError("Error expanding file args", err)
 	}

--- a/cmd/cli/app/ruletype/ruletype_create.go
+++ b/cmd/cli/app/ruletype/ruletype_create.go
@@ -40,7 +40,7 @@ func createCommand(_ context.Context, cmd *cobra.Command, _ []string, conn *grpc
 		return cli.MessageAndError("Error validating file flag", err)
 	}
 
-	files, err := util.ExpandFileArgs(fileFlag)
+	files, err := util.ExpandFileArgs(fileFlag...)
 	if err != nil {
 		return cli.MessageAndError("Error expanding file args", err)
 	}

--- a/cmd/dev/app/rule_type/lint.go
+++ b/cmd/dev/app/rule_type/lint.go
@@ -17,7 +17,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/mindersec/minder/internal/engine/eval/rego"
-	"github.com/mindersec/minder/internal/util/cli"
+	"github.com/mindersec/minder/internal/util"
 	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -46,63 +46,69 @@ func lintCmdRun(cmd *cobra.Command, _ []string) error {
 	skipRego := cmd.Flag("skip-rego").Value.String() == "true"
 
 	ctx := cmd.Context()
-
 	rtpathStr := rtpath.Value.String()
 
+	files, err := util.ExpandFileArgs(rtpathStr)
+	if err != nil {
+		return fmt.Errorf("error expanding file args: %w", err)
+	}
+
 	var errors []error
-	walkerr := filepath.Walk(rtpathStr, func(path string, info os.FileInfo, walkerr error) error {
-		if walkerr != nil {
-			return fmt.Errorf("error walking path %s: %w", path, walkerr)
+	for _, f := range files {
+		if shouldSkipFile(f.Path) {
+			continue
 		}
 
-		if info.IsDir() {
-			return nil
+		rt, err := readRuleTypeFromFile(f.Path)
+		if err != nil && f.Expanded && minderv1.YouMayHaveTheWrongResource(err) {
+			cmd.PrintErrf("Skipping file %s: not a rule type\n", f.Path)
+			continue
 		}
-
-		if !cli.IsYAMLFileAndNotATest(path) {
-			return nil
-		}
-
-		rt, err := readRuleTypeFromFile(path)
 		if err != nil {
-			errors = append(errors, fmt.Errorf("error reading rule type from file %s: %w", path, err))
-			return nil
+			errors = append(errors, fmt.Errorf("error reading rule type from file %s: %w", f.Path, err))
+			continue
 		}
 
 		if err := rt.Validate(); err != nil {
-			errors = append(errors, fmt.Errorf("error validating rule type: %w", err))
-			return nil
+			errors = append(errors, fmt.Errorf("error validating rule type from file %s: %w", f.Path, err))
+			continue
 		}
-
 		// get file name without extension
-		ruleName := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+		ruleName := strings.TrimSuffix(filepath.Base(f.Path), filepath.Ext(f.Path))
 		if rt.Name != ruleName {
 			errors = append(errors, fmt.Errorf("rule type name does not match file name: %s != %s", rt.Name, ruleName))
-			return nil
+			continue
 		}
 
 		if rt.Def.Eval.Type == rego.RegoEvalType && !skipRego {
 			if err := validateRegoRule(ctx, rt.Def.Eval.Rego, rtpathStr, cmd.OutOrStdout()); err != nil {
-				errors = append(errors, fmt.Errorf("failed validating rego rule: %w", err))
-				return nil
+				errors = append(errors, fmt.Errorf("failed validating rego rule from file %s: %w", f.Path, err))
+				continue
 			}
 		}
-
-		return nil
-	})
-
-	if walkerr != nil {
-		return fmt.Errorf("error walking path %s: %w", rtpathStr, walkerr)
 	}
 
 	if len(errors) > 0 {
 		for _, err := range errors {
-			fmt.Fprintln(cmd.ErrOrStderr(), err)
+			cmd.PrintErrf("%s\n", err)
 		}
 		return fmt.Errorf("failed linting rule type")
 	}
 
 	return nil
+}
+
+func shouldSkipFile(f string) bool {
+	// if the file is not json or yaml, skip it
+	// Get file extension
+	ext := filepath.Ext(f)
+	switch ext {
+	case ".yaml", ".yml", ".json":
+		return false
+	default:
+		fmt.Fprintf(os.Stderr, "Skipping file %s: not a yaml or json file\n", f)
+		return true
+	}
 }
 
 func validateRegoRule(ctx context.Context, r *minderv1.RuleType_Definition_Eval_Rego, path string, out io.Writer) error {


### PR DESCRIPTION
# Summary

We recently changed the behaviour of `minder ruletype create` and `apply` to ignore files that do not define rule types. This allowed us to add test files to `mindersec/minder-rules-and-profiles`, but it in turn broke `mindev`.

This change makes `mindev` behave like `minder` by splitting folder walk from ruletype validation.

Fixes #4819

## Change Type

***Mark the type of change your PR introduces:***

- [X] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [X] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manually ran the following commands pre- and post-fix.
```
mindev ruletype lint -r ~/stacklok/minder-rules-and-profiles/rule-types/ --skip-rego
mindev ruletype lint -r ~/stacklok/minder-rules-and-profiles/rule-types/common/license.yaml --skip-rego
minder ruletype create -f ~/stacklok/minder-rules-and-profiles/rule-types/
```

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
