### PR TITLE
Fix a 0.2% natschannel_test flake with some forced scheduler sleeps

### DIFF
--- a/internal/events/nats/natschannel_test.go
+++ b/internal/events/nats/natschannel_test.go
@@ -66,10 +66,11 @@ func TestNatsChannel(t *testing.T) {
 	// the last message published be dropped if the following Close call
 	// is within a few milliseconds of the Publish call.
 	time.Sleep(5 * time.Millisecond)
-	// Don't let sub1 see the last message, even though it's published by pub1.
+	// Don't let sub1 see the last two messages, even though it's published by pub1.
 	if err := sub1.Close(); err != nil {
 		t.Fatalf("failed to close sub1: %v", err)
 	}
+	time.Sleep(5 * time.Millisecond)
 	if err := pub2.Publish("test", m3); err != nil {
 		t.Fatalf("failed to publish message: %v", err)
 	}


### PR DESCRIPTION
# Summary

I noticed `natschannel_test` failing in a CI run (which seem to run on a slower CPU than my MacBook).  I was able to reproduce with `-count 1000` with some background adversarial tasks.  Putting in a forced scheduler transition (aka `time.Sleep`) after closing the subscriber seemed to prevent losing the third message (it was always the third message, which made me suspect the lines just before that publish).

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

`go test -count 1000 ./internal/events/nats` while running `go test -count 2 ./...` in parallel in another window.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
