### PR TITLE
Have run-docker-teardown respect services variable

### DIFF
--- a/.mk/develop.mk
+++ b/.mk/develop.mk
@@ -21,8 +21,8 @@ run-server: ## run the app
 .PHONY: run-docker-teardown
 run-docker-teardown: ## teardown the docker compose environment
 ifeq ($(RUN_DOCKER_NO_TEARDOWN),false)
-	@echo "Running docker compose down"
-	@$(COMPOSE) down
+	@echo "Running docker compose down $(services)..."
+	@$(COMPOSE) down $(services)
 else
 	@echo "Skipping docker compose down"
 endif
@@ -42,7 +42,7 @@ run-docker: run-docker-teardown ## run the app under docker compose
 .PHONY: stop-docker
 stop-docker: ## stop the app under docker compose
 	@echo "Running docker compose down $(services)..."
-	@$(COMPOSE) down
+	@$(COMPOSE) down $(services)
 
 .PHONY: pre-commit
 pre-commit:	## run pre-commit hooks

--- a/docs/docs/developer_guide/get-hacking.md
+++ b/docs/docs/developer_guide/get-hacking.md
@@ -10,6 +10,11 @@ Follow the steps in the [Installing a Development version](./../run_minder_serve
 
 The application will be available on `https://localhost:8080` and gRPC on `https://localhost:8090`.
 
+When iterating, it can be helpful to only rebuild and reload the `minder` container.  You can do this with:
+```bash
+make run-docker services=minder
+```
+
 ## Run the tests
 ```bash
 make test


### PR DESCRIPTION
# Summary

I wanted to run `make run-docker services=minder` to only reload minder without tearing down keycloak, openfga, or the postgres DB.  Unfortunately, `run-docker` depends on `run-docker-teardown`, which didn't qualify the services being shut down.  This fixes that, so you can iterate with the prevous command.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

I've been using this to speed up my manual test loop.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
