### PR TITLE
Fix nil flag client, and warn about use in future

### DIFF
--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -39,6 +39,10 @@ func fromContext(ctx context.Context) openfeature.EvaluationContext {
 
 // Bool provides a simple wrapper around client.Boolean to normalize usage for Minder.
 func Bool(ctx context.Context, client openfeature.IClient, feature Experiment) bool {
+	if client == nil {
+		zerolog.Ctx(ctx).Debug().Str("flag", string(feature)).Msg("Bool called with <nil> client, returning false")
+		return false
+	}
 	ret := client.Boolean(ctx, string(feature), false, fromContext(ctx))
 	// TODO: capture in telemetry records
 	return ret

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -76,7 +76,7 @@ func AllInOneServerService(
 	flags.OpenFeatureProviderFromFlags(ctx, cfg.Flags)
 	featureFlagClient := openfeature.NewClient(cfg.Flags.AppName)
 
-	evt, err := eventer.New(ctx, nil, &cfg.Events)
+	evt, err := eventer.New(ctx, featureFlagClient, &cfg.Events)
 	if err != nil {
 		return fmt.Errorf("unable to setup eventer: %w", err)
 	}


### PR DESCRIPTION
# Summary

When merging #4784, I missed that I needed to update `services.go` to pass the flag client.  This led to a `nil` interface in `Bool()` and a panic.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

This shows up real fast as a failure to publish messages when running the server.  The panic is caught, but no message is published.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
