### PR TITLE
Sort profile status table by entities

### DIFF
--- a/cmd/cli/app/profile/table_render.go
+++ b/cmd/cli/app/profile/table_render.go
@@ -4,6 +4,9 @@
 package profile
 
 import (
+	"fmt"
+	"slices"
+	"strings"
 	"time"
 
 	"google.golang.org/protobuf/types/known/structpb"
@@ -104,11 +107,15 @@ func RenderRuleEvaluationStatusTable(
 	statuses []*minderv1.RuleEvaluationStatus,
 	t table.Table,
 ) {
+	// sort by entity
+	slices.SortFunc(statuses, func(a *minderv1.RuleEvaluationStatus, b *minderv1.RuleEvaluationStatus) int {
+		return strings.Compare(a.EntityInfo["name"], b.EntityInfo["name"])
+	})
+
 	for _, eval := range statuses {
 		t.AddRowWithColor(
-			layouts.NoColor(eval.RuleDescriptionName),
-			layouts.NoColor(eval.RuleTypeName),
-			layouts.NoColor(eval.Entity),
+			layouts.NoColor(fmt.Sprintf("%s\n[%s]", eval.RuleDescriptionName, eval.RuleTypeName)),
+			layouts.NoColor(fmt.Sprintf("%s\n[%s]", eval.EntityInfo["name"], eval.Entity)),
 			common.GetEvalStatusColor(eval.Status),
 			common.GetRemediateStatusColor(eval.RemediationStatus),
 			layouts.NoColor(mapToYAMLOrEmpty(eval.EntityInfo)),

--- a/internal/util/cli/table/simple/simple.go
+++ b/internal/util/cli/table/simple/simple.go
@@ -106,7 +106,7 @@ func profileStatusLayout(table *tablewriter.Table) {
 func ruleEvaluationsLayout(table *tablewriter.Table) {
 	defaultLayout(table)
 	table.SetHeader([]string{
-		"Rule Name", "Rule Type", "Entity", "Status", "Remediation", "Entity Info"})
+		"Rule Name", "Entity", "Status", "Remediation", "Entity Info"})
 	table.SetAutoMergeCellsByColumnIndex([]int{0, 1})
 	// This is needed for the rule definition and rule parameters
 	table.SetAutoWrapText(true)


### PR DESCRIPTION
# Summary

This sorts the list of profile statuses by entity, rather than mixing all rule types and entities together in database order.  I'll include a before/after screenshot, but this makes it much easier (for me) to interpret the output of `minder profile status list --detailed -n <my-one-profile>`

Before (note that some rows combine multiple entities under one rule type, but the same rule type is also repeated later):
![image](https://github.com/user-attachments/assets/415d53f3-60e3-4ceb-b480-cdb391ef3800)

After (I also did some formatting to narrow the table by combining columns using newlines to separate related data):
![image](https://github.com/user-attachments/assets/db482d6c-ade0-40bd-965c-0d395270697c)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual testing by running the command.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
