### PR TITLE
Bump `trusty-sdk-go` to latest release.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/sqlc-dev/pqtype v0.3.0
 	github.com/stacklok/frizbee v0.1.4
-	github.com/stacklok/trusty-sdk-go v0.2.1
+	github.com/stacklok/trusty-sdk-go v0.2.2
 	github.com/stretchr/testify v1.9.0
 	github.com/styrainc/regal v0.28.0
 	github.com/thomaspoignant/go-feature-flag v1.37.1

--- a/go.sum
+++ b/go.sum
@@ -1017,8 +1017,8 @@ github.com/sqlc-dev/pqtype v0.3.0 h1:b09TewZ3cSnO5+M1Kqq05y0+OjqIptxELaSayg7bmqk
 github.com/sqlc-dev/pqtype v0.3.0/go.mod h1:oyUjp5981ctiL9UYvj1bVvCKi8OXkCa0u645hce7CAs=
 github.com/stacklok/frizbee v0.1.4 h1:00v6/2HBmwzNdOyVAP4e1isOeUAIWTlb5eggoNUpHmk=
 github.com/stacklok/frizbee v0.1.4/go.mod h1:rFA90VkGFYLb7qCiUniAihmkgXfZAj2BnfF6jR8Csro=
-github.com/stacklok/trusty-sdk-go v0.2.1 h1:4y0nVAmM3nSi3MCU6AO1rY3Iqdg/cQIqVxqxj+977c8=
-github.com/stacklok/trusty-sdk-go v0.2.1/go.mod h1:JjZ0KWyQ5Hbgr9J4vAcKn/uBaWk+WrthWkk7G6HXeMs=
+github.com/stacklok/trusty-sdk-go v0.2.2 h1:55B2DrneLYZXxBaNEeyRMGac7mj+pFbrKomx/hSxUyI=
+github.com/stacklok/trusty-sdk-go v0.2.2/go.mod h1:BbXNVVT32meuxyJuO4pmXRzVPjc/9AXob2sBbOPiKpk=
 github.com/stoewer/go-strcase v1.3.0 h1:g0eASXYtp+yvN9fK8sH94oCIk0fau9uV1/ZdJ0AVEzs=
 github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/engine/eval/trusty/actions.go
+++ b/internal/engine/eval/trusty/actions.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/google/go-github/v63/github"
 	"github.com/rs/zerolog"
-	trustytypes "github.com/stacklok/trusty-sdk-go/pkg/types"
+	trustytypes "github.com/stacklok/trusty-sdk-go/pkg/v1/types"
 
 	"github.com/mindersec/minder/internal/constants"
 	"github.com/mindersec/minder/internal/engine/eval/pr_actions"

--- a/internal/engine/eval/trusty/actions_test.go
+++ b/internal/engine/eval/trusty/actions_test.go
@@ -7,7 +7,7 @@ package trusty
 import (
 	"testing"
 
-	trustytypes "github.com/stacklok/trusty-sdk-go/pkg/types"
+	trustytypes "github.com/stacklok/trusty-sdk-go/pkg/v1/types"
 	"github.com/stretchr/testify/require"
 
 	v1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"

--- a/internal/engine/eval/trusty/trusty.go
+++ b/internal/engine/eval/trusty/trusty.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 
 	"github.com/rs/zerolog"
-	trusty "github.com/stacklok/trusty-sdk-go/pkg/client"
-	trustytypes "github.com/stacklok/trusty-sdk-go/pkg/types"
+	trusty "github.com/stacklok/trusty-sdk-go/pkg/v1/client"
+	trustytypes "github.com/stacklok/trusty-sdk-go/pkg/v1/types"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	evalerrors "github.com/mindersec/minder/internal/engine/errors"

--- a/internal/engine/eval/trusty/trusty_test.go
+++ b/internal/engine/eval/trusty/trusty_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
-	trustytypes "github.com/stacklok/trusty-sdk-go/pkg/types"
+	trustytypes "github.com/stacklok/trusty-sdk-go/pkg/v1/types"
 	"github.com/stretchr/testify/require"
 
 	evalerrors "github.com/mindersec/minder/internal/engine/errors"


### PR DESCRIPTION
# Summary

The latest release only moves some files around, maintaining the same public interface. Packages `pkg/types` and `pkg/client` are deprecated in favor of `pkg/v1/types` and `pkg/v1/client`, respectively, and `pkg/v2` will be added soon.

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [X] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

It builds.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
