### PR TITLE
Print YAML with 2 spaces for indentation

### DIFF
--- a/internal/util/jsonyaml/jsonyamlutils.go
+++ b/internal/util/jsonyaml/jsonyamlutils.go
@@ -38,7 +38,9 @@ func TranscodeYAMLToJSON(r io.Reader, w io.Writer) error {
 
 // TranscodeJSONToYAML transcodes JSON to YAML
 func TranscodeJSONToYAML(r io.Reader, w io.Writer) error {
-	return transcode(json.NewDecoder(r), yaml.NewEncoder(w))
+	enc := yaml.NewEncoder(w)
+	enc.SetIndent(2)
+	return transcode(json.NewDecoder(r), enc)
 }
 
 // ConvertYamlToJson converts yaml to json

--- a/internal/util/jsonyaml/jsonyamlutils_test.go
+++ b/internal/util/jsonyaml/jsonyamlutils_test.go
@@ -83,9 +83,9 @@ func TestConvertJSONToYAML(t *testing.T) {
 			name:     "complex yaml",
 			jsonCase: "{\"bar\":[\"foo\",\"bar\",\"baz\"],\"foo\":\"bar\"}\n",
 			wantW: `bar:
-    - foo
-    - bar
-    - baz
+  - foo
+  - bar
+  - baz
 foo: bar
 `,
 			wantErr: false,


### PR DESCRIPTION
# Summary

We were using the default, which is 4. This gets the output to be quite
verbose. The standard is to use 2 spaces, so let's use that when
printing YAML in Minder.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
