### PR TITLE
Add entitlements assignment at the time of project creation

### DIFF
--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -192,18 +192,18 @@ func (mr *MockStoreMockRecorder) CountUsers(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountUsers", reflect.TypeOf((*MockStore)(nil).CountUsers), ctx)
 }
 
-// CreateEntitlement mocks base method.
-func (m *MockStore) CreateEntitlement(ctx context.Context, arg db.CreateEntitlementParams) error {
+// CreateEntitlements mocks base method.
+func (m *MockStore) CreateEntitlements(ctx context.Context, arg db.CreateEntitlementsParams) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateEntitlement", ctx, arg)
+	ret := m.ctrl.Call(m, "CreateEntitlements", ctx, arg)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// CreateEntitlement indicates an expected call of CreateEntitlement.
-func (mr *MockStoreMockRecorder) CreateEntitlement(ctx, arg any) *gomock.Call {
+// CreateEntitlements indicates an expected call of CreateEntitlements.
+func (mr *MockStoreMockRecorder) CreateEntitlements(ctx, arg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEntitlement", reflect.TypeOf((*MockStore)(nil).CreateEntitlement), ctx, arg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEntitlements", reflect.TypeOf((*MockStore)(nil).CreateEntitlements), ctx, arg)
 }
 
 // CreateEntity mocks base method.

--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -192,6 +192,20 @@ func (mr *MockStoreMockRecorder) CountUsers(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountUsers", reflect.TypeOf((*MockStore)(nil).CountUsers), ctx)
 }
 
+// CreateEntitlement mocks base method.
+func (m *MockStore) CreateEntitlement(ctx context.Context, arg db.CreateEntitlementParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateEntitlement", ctx, arg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateEntitlement indicates an expected call of CreateEntitlement.
+func (mr *MockStoreMockRecorder) CreateEntitlement(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEntitlement", reflect.TypeOf((*MockStore)(nil).CreateEntitlement), ctx, arg)
+}
+
 // CreateEntity mocks base method.
 func (m *MockStore) CreateEntity(ctx context.Context, arg db.CreateEntityParams) (db.EntityInstance, error) {
 	m.ctrl.T.Helper()

--- a/database/query/entitlements.sql
+++ b/database/query/entitlements.sql
@@ -10,3 +10,7 @@ WHERE e.project_id = sqlc.arg(project_id)::UUID AND e.feature = sqlc.arg(feature
 SELECT feature
 FROM entitlements
 WHERE project_id = sqlc.arg(project_id)::UUID;
+
+-- name: CreateEntitlement :exec
+INSERT INTO entitlements (feature, project_id) VALUES ($1, $2)
+ON CONFLICT DO NOTHING;

--- a/database/query/entitlements.sql
+++ b/database/query/entitlements.sql
@@ -13,5 +13,5 @@ WHERE project_id = sqlc.arg(project_id)::UUID;
 
 -- name: CreateEntitlements :exec
 INSERT INTO entitlements (feature, project_id)
-SELECT unnest($1::text[]), $2::UUID
+SELECT unnest(sqlc.arg(features)::text[]), sqlc.arg(project_id)::UUID
 ON CONFLICT DO NOTHING;

--- a/database/query/entitlements.sql
+++ b/database/query/entitlements.sql
@@ -11,6 +11,7 @@ SELECT feature
 FROM entitlements
 WHERE project_id = sqlc.arg(project_id)::UUID;
 
--- name: CreateEntitlement :exec
-INSERT INTO entitlements (feature, project_id) VALUES ($1, $2)
+-- name: CreateEntitlements :exec
+INSERT INTO entitlements (feature, project_id)
+SELECT unnest($1::text[]), $2::UUID
 ON CONFLICT DO NOTHING;

--- a/internal/controlplane/handlers_projects.go
+++ b/internal/controlplane/handlers_projects.go
@@ -161,12 +161,6 @@ func (s *Server) CreateProject(
 			"project does not allow project hierarchy operations")
 	}
 
-	// Retrieve the role-to-feature mapping from the configuration
-	projectFeatures, err := s.cfg.Features.GetFeaturesForRoles(ctx)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "error getting features for roles: %v", err)
-	}
-
 	tx, err := s.store.BeginTransaction()
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "error starting transaction: %v", err)
@@ -207,6 +201,8 @@ func (s *Server) CreateProject(
 		return nil, status.Errorf(codes.Internal, "error creating subproject: %v", err)
 	}
 
+	// Retrieve the role-to-feature mapping from the configuration
+	projectFeatures := s.cfg.Features.GetFeaturesForRoles(ctx)
 	if err := features.CreateEntitlements(ctx, qtx, subProject.ID, projectFeatures); err != nil {
 		return nil, status.Errorf(codes.Internal, "error creating entitlements: %v", err)
 	}

--- a/internal/controlplane/handlers_projects.go
+++ b/internal/controlplane/handlers_projects.go
@@ -203,7 +203,10 @@ func (s *Server) CreateProject(
 
 	// Retrieve the membership-to-feature mapping from the configuration
 	projectFeatures := s.cfg.Features.GetFeaturesForMemberships(ctx)
-	if err := features.CreateEntitlements(ctx, qtx, subProject.ID, projectFeatures); err != nil {
+	if err := qtx.CreateEntitlements(ctx, db.CreateEntitlementsParams{
+		Column1: projectFeatures,
+		Column2: subProject.ID,
+	}); err != nil {
 		return nil, status.Errorf(codes.Internal, "error creating entitlements: %v", err)
 	}
 

--- a/internal/controlplane/handlers_projects.go
+++ b/internal/controlplane/handlers_projects.go
@@ -201,8 +201,8 @@ func (s *Server) CreateProject(
 		return nil, status.Errorf(codes.Internal, "error creating subproject: %v", err)
 	}
 
-	// Retrieve the role-to-feature mapping from the configuration
-	projectFeatures := s.cfg.Features.GetFeaturesForRoles(ctx)
+	// Retrieve the membership-to-feature mapping from the configuration
+	projectFeatures := s.cfg.Features.GetFeaturesForMemberships(ctx)
 	if err := features.CreateEntitlements(ctx, qtx, subProject.ID, projectFeatures); err != nil {
 		return nil, status.Errorf(codes.Internal, "error creating entitlements: %v", err)
 	}

--- a/internal/controlplane/handlers_projects.go
+++ b/internal/controlplane/handlers_projects.go
@@ -204,8 +204,8 @@ func (s *Server) CreateProject(
 	// Retrieve the membership-to-feature mapping from the configuration
 	projectFeatures := s.cfg.Features.GetFeaturesForMemberships(ctx)
 	if err := qtx.CreateEntitlements(ctx, db.CreateEntitlementsParams{
-		Column1: projectFeatures,
-		Column2: subProject.ID,
+		Features:  projectFeatures,
+		ProjectID: subProject.ID,
 	}); err != nil {
 		return nil, status.Errorf(codes.Internal, "error creating entitlements: %v", err)
 	}

--- a/internal/db/entitlements.sql.go
+++ b/internal/db/entitlements.sql.go
@@ -20,12 +20,12 @@ ON CONFLICT DO NOTHING
 `
 
 type CreateEntitlementsParams struct {
-	Column1 []string  `json:"column_1"`
-	Column2 uuid.UUID `json:"column_2"`
+	Features  []string  `json:"features"`
+	ProjectID uuid.UUID `json:"project_id"`
 }
 
 func (q *Queries) CreateEntitlements(ctx context.Context, arg CreateEntitlementsParams) error {
-	_, err := q.db.ExecContext(ctx, createEntitlements, pq.Array(arg.Column1), arg.Column2)
+	_, err := q.db.ExecContext(ctx, createEntitlements, pq.Array(arg.Features), arg.ProjectID)
 	return err
 }
 

--- a/internal/db/entitlements.sql.go
+++ b/internal/db/entitlements.sql.go
@@ -12,6 +12,21 @@ import (
 	"github.com/google/uuid"
 )
 
+const createEntitlement = `-- name: CreateEntitlement :exec
+INSERT INTO entitlements (feature, project_id) VALUES ($1, $2)
+ON CONFLICT DO NOTHING
+`
+
+type CreateEntitlementParams struct {
+	Feature   string    `json:"feature"`
+	ProjectID uuid.UUID `json:"project_id"`
+}
+
+func (q *Queries) CreateEntitlement(ctx context.Context, arg CreateEntitlementParams) error {
+	_, err := q.db.ExecContext(ctx, createEntitlement, arg.Feature, arg.ProjectID)
+	return err
+}
+
 const getEntitlementFeaturesByProjectID = `-- name: GetEntitlementFeaturesByProjectID :many
 SELECT feature
 FROM entitlements

--- a/internal/db/entitlements.sql.go
+++ b/internal/db/entitlements.sql.go
@@ -10,20 +10,22 @@ import (
 	"encoding/json"
 
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 )
 
-const createEntitlement = `-- name: CreateEntitlement :exec
-INSERT INTO entitlements (feature, project_id) VALUES ($1, $2)
+const createEntitlements = `-- name: CreateEntitlements :exec
+INSERT INTO entitlements (feature, project_id)
+SELECT unnest($1::text[]), $2::UUID
 ON CONFLICT DO NOTHING
 `
 
-type CreateEntitlementParams struct {
-	Feature   string    `json:"feature"`
-	ProjectID uuid.UUID `json:"project_id"`
+type CreateEntitlementsParams struct {
+	Column1 []string  `json:"column_1"`
+	Column2 uuid.UUID `json:"column_2"`
 }
 
-func (q *Queries) CreateEntitlement(ctx context.Context, arg CreateEntitlementParams) error {
-	_, err := q.db.ExecContext(ctx, createEntitlement, arg.Feature, arg.ProjectID)
+func (q *Queries) CreateEntitlements(ctx context.Context, arg CreateEntitlementsParams) error {
+	_, err := q.db.ExecContext(ctx, createEntitlements, pq.Array(arg.Column1), arg.Column2)
 	return err
 }
 

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -20,6 +20,7 @@ type Querier interface {
 	CountRepositories(ctx context.Context) (int64, error)
 	CountRepositoriesByProjectID(ctx context.Context, projectID uuid.UUID) (int64, error)
 	CountUsers(ctx context.Context) (int64, error)
+	CreateEntitlement(ctx context.Context, arg CreateEntitlementParams) error
 	// CreateEntity adds an entry to the entity_instances table so it can be tracked by Minder.
 	CreateEntity(ctx context.Context, arg CreateEntityParams) (EntityInstance, error)
 	// CreateEntityWithID adds an entry to the entities table with a specific ID so it can be tracked by Minder.

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -20,7 +20,7 @@ type Querier interface {
 	CountRepositories(ctx context.Context) (int64, error)
 	CountRepositoriesByProjectID(ctx context.Context, projectID uuid.UUID) (int64, error)
 	CountUsers(ctx context.Context) (int64, error)
-	CreateEntitlement(ctx context.Context, arg CreateEntitlementParams) error
+	CreateEntitlements(ctx context.Context, arg CreateEntitlementsParams) error
 	// CreateEntity adds an entry to the entity_instances table so it can be tracked by Minder.
 	CreateEntity(ctx context.Context, arg CreateEntityParams) (EntityInstance, error)
 	// CreateEntityWithID adds an entry to the entities table with a specific ID so it can be tracked by Minder.

--- a/internal/projects/creator.go
+++ b/internal/projects/creator.go
@@ -15,7 +15,6 @@ import (
 	"github.com/mindersec/minder/internal/authz"
 	"github.com/mindersec/minder/internal/db"
 	"github.com/mindersec/minder/internal/marketplaces"
-	"github.com/mindersec/minder/internal/projects/features"
 	"github.com/mindersec/minder/pkg/config/server"
 	"github.com/mindersec/minder/pkg/mindpak"
 )
@@ -111,7 +110,10 @@ func (p *projectCreator) ProvisionSelfEnrolledProject(
 
 	// Retrieve the membership-to-feature mapping from the configuration
 	projectFeatures := p.featuresCfg.GetFeaturesForMemberships(ctx)
-	if err := features.CreateEntitlements(ctx, qtx, project.ID, projectFeatures); err != nil {
+	if err := qtx.CreateEntitlements(ctx, db.CreateEntitlementsParams{
+		Column1: projectFeatures,
+		Column2: project.ID,
+	}); err != nil {
 		return nil, fmt.Errorf("error creating entitlements: %w", err)
 	}
 

--- a/internal/projects/creator.go
+++ b/internal/projects/creator.go
@@ -79,12 +79,6 @@ func (p *projectCreator) ProvisionSelfEnrolledProject(
 		return nil, fmt.Errorf("failed to marshal meta: %w", err)
 	}
 
-	// Retrieve the role-to-feature mapping from the configuration
-	projectFeatures, err := p.featuresCfg.GetFeaturesForRoles(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("error getting features for roles: %w", err)
-	}
-
 	projectID := uuid.New()
 
 	// Create authorization tuple
@@ -115,6 +109,8 @@ func (p *projectCreator) ProvisionSelfEnrolledProject(
 		return nil, fmt.Errorf("failed to create default project: %v", err)
 	}
 
+	// Retrieve the role-to-feature mapping from the configuration
+	projectFeatures := p.featuresCfg.GetFeaturesForRoles(ctx)
 	if err := features.CreateEntitlements(ctx, qtx, project.ID, projectFeatures); err != nil {
 		return nil, fmt.Errorf("error creating entitlements: %w", err)
 	}

--- a/internal/projects/creator.go
+++ b/internal/projects/creator.go
@@ -111,8 +111,8 @@ func (p *projectCreator) ProvisionSelfEnrolledProject(
 	// Retrieve the membership-to-feature mapping from the configuration
 	projectFeatures := p.featuresCfg.GetFeaturesForMemberships(ctx)
 	if err := qtx.CreateEntitlements(ctx, db.CreateEntitlementsParams{
-		Column1: projectFeatures,
-		Column2: project.ID,
+		Features:  projectFeatures,
+		ProjectID: project.ID,
 	}); err != nil {
 		return nil, fmt.Errorf("error creating entitlements: %w", err)
 	}

--- a/internal/projects/creator.go
+++ b/internal/projects/creator.go
@@ -109,8 +109,8 @@ func (p *projectCreator) ProvisionSelfEnrolledProject(
 		return nil, fmt.Errorf("failed to create default project: %v", err)
 	}
 
-	// Retrieve the role-to-feature mapping from the configuration
-	projectFeatures := p.featuresCfg.GetFeaturesForRoles(ctx)
+	// Retrieve the membership-to-feature mapping from the configuration
+	projectFeatures := p.featuresCfg.GetFeaturesForMemberships(ctx)
 	if err := features.CreateEntitlements(ctx, qtx, project.ID, projectFeatures); err != nil {
 		return nil, fmt.Errorf("error creating entitlements: %w", err)
 	}

--- a/internal/projects/creator_test.go
+++ b/internal/projects/creator_test.go
@@ -38,7 +38,7 @@ func TestProvisionSelfEnrolledProject(t *testing.T) {
 			ID: uuid.New(),
 		}, nil)
 	mockStore.EXPECT().CreateEntitlements(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, params db.CreateEntitlementsParams) error {
+		DoAndReturn(func(_ context.Context, params db.CreateEntitlementsParams) error {
 			expectedFeatures := []string{"featureA", "featureB"}
 			if !reflect.DeepEqual(params.Column1, expectedFeatures) {
 				t.Errorf("expected features %v, got %v", expectedFeatures, params.Column1)

--- a/internal/projects/creator_test.go
+++ b/internal/projects/creator_test.go
@@ -40,13 +40,13 @@ func TestProvisionSelfEnrolledProject(t *testing.T) {
 	mockStore.EXPECT().CreateEntitlements(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, params db.CreateEntitlementsParams) error {
 			expectedFeatures := []string{"featureA", "featureB"}
-			if !reflect.DeepEqual(params.Column1, expectedFeatures) {
-				t.Errorf("expected features %v, got %v", expectedFeatures, params.Column1)
+			if !reflect.DeepEqual(params.Features, expectedFeatures) {
+				t.Errorf("expected features %v, got %v", expectedFeatures, params.Features)
 			}
 			return nil
 		})
 
-	ctx := prepareTestToken(t, []any{
+	ctx := prepareTestToken(context.Background(), t, []any{
 		"teamA",
 		"teamB",
 		"teamC",
@@ -130,7 +130,7 @@ func TestProvisionSelfEnrolledProjectInvalidName(t *testing.T) {
 }
 
 // prepareTestToken creates a JWT token with the specified roles and returns the context with the token.
-func prepareTestToken(t *testing.T, roles []any) context.Context {
+func prepareTestToken(ctx context.Context, t *testing.T, roles []any) context.Context {
 	t.Helper()
 
 	token := openid.New()
@@ -138,6 +138,5 @@ func prepareTestToken(t *testing.T, roles []any) context.Context {
 		"roles": roles,
 	}))
 
-	ctx := jwt.WithAuthTokenContext(context.Background(), token)
-	return ctx
+	return jwt.WithAuthTokenContext(ctx, token)
 }

--- a/internal/projects/creator_test.go
+++ b/internal/projects/creator_test.go
@@ -10,12 +10,12 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/lestrrat-go/jwx/v2/jwt/openid"
-	"github.com/mindersec/minder/internal/auth/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	mockdb "github.com/mindersec/minder/database/mock"
+	"github.com/mindersec/minder/internal/auth/jwt"
 	"github.com/mindersec/minder/internal/authz/mock"
 	"github.com/mindersec/minder/internal/db"
 	"github.com/mindersec/minder/internal/marketplaces"

--- a/internal/projects/features/features.go
+++ b/internal/projects/features/features.go
@@ -30,6 +30,22 @@ func ProjectAllowsProjectHierarchyOperations(ctx context.Context, store db.Store
 	return featureEnabled(ctx, store, projectID, projectHierarchyOperationsEnabledFlag)
 }
 
+// CreateEntitlements creates entitlements for a project
+// It takes a 'qtx' because it is usually called within a transaction
+func CreateEntitlements(ctx context.Context, qtx db.Querier, projectID uuid.UUID, features []string) error {
+	for _, feature := range features {
+		err := qtx.CreateEntitlement(ctx, db.CreateEntitlementParams{
+			ProjectID: projectID,
+			Feature:   feature,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // Is a simple helper function to check if a feature is enabled for a project.
 // This does not check the feature's configuration, if any, just that it's enabled.
 func featureEnabled(ctx context.Context, store db.Store, projectID uuid.UUID, featureFlag string) bool {

--- a/internal/projects/features/features.go
+++ b/internal/projects/features/features.go
@@ -31,16 +31,12 @@ func ProjectAllowsProjectHierarchyOperations(ctx context.Context, store db.Store
 }
 
 // CreateEntitlements creates entitlements for a project
-// It takes a 'qtx' because it is usually called within a transaction
 func CreateEntitlements(ctx context.Context, qtx db.Querier, projectID uuid.UUID, features []string) error {
-	for _, feature := range features {
-		err := qtx.CreateEntitlement(ctx, db.CreateEntitlementParams{
-			ProjectID: projectID,
-			Feature:   feature,
-		})
-		if err != nil {
-			return err
-		}
+	if err := qtx.CreateEntitlements(ctx, db.CreateEntitlementsParams{
+		Column1: features,
+		Column2: projectID,
+	}); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/projects/features/features.go
+++ b/internal/projects/features/features.go
@@ -30,18 +30,6 @@ func ProjectAllowsProjectHierarchyOperations(ctx context.Context, store db.Store
 	return featureEnabled(ctx, store, projectID, projectHierarchyOperationsEnabledFlag)
 }
 
-// CreateEntitlements creates entitlements for a project
-func CreateEntitlements(ctx context.Context, qtx db.Querier, projectID uuid.UUID, features []string) error {
-	if err := qtx.CreateEntitlements(ctx, db.CreateEntitlementsParams{
-		Column1: features,
-		Column2: projectID,
-	}); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // Is a simple helper function to check if a feature is enabled for a project.
 // This does not check the feature's configuration, if any, just that it's enabled.
 func featureEnabled(ctx context.Context, store db.Store, projectID uuid.UUID, featureFlag string) bool {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -102,7 +102,7 @@ func AllInOneServerService(
 	fallbackTokenClient := ghprov.NewFallbackTokenClient(cfg.Provider)
 	ghClientFactory := clients.NewGitHubClientFactory(providerMetrics)
 	providerStore := providers.NewProviderStore(store)
-	projectCreator := projects.NewProjectCreator(authzClient, marketplace, &cfg.DefaultProfiles)
+	projectCreator := projects.NewProjectCreator(authzClient, marketplace, &cfg.DefaultProfiles, &cfg.Features)
 	propSvc := propService.NewPropertiesService(store)
 
 	// TODO: isolate GitHub-specific wiring. We'll need to isolate GitHub

--- a/pkg/config/server/config.go
+++ b/pkg/config/server/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	Auth            AuthConfig            `mapstructure:"auth"`
 	WebhookConfig   WebhookConfig         `mapstructure:"webhook-config"`
 	Events          EventConfig           `mapstructure:"events"`
+	Features        FeaturesConfig        `mapstructure:"features"`
 	Authz           AuthzConfig           `mapstructure:"authz"`
 	Provider        ProviderConfig        `mapstructure:"provider"`
 	Marketplace     MarketplaceConfig     `mapstructure:"marketplace"`

--- a/pkg/config/server/features.go
+++ b/pkg/config/server/features.go
@@ -11,17 +11,17 @@ import (
 
 // FeaturesConfig is the configuration for the features
 type FeaturesConfig struct {
-	// RoleFeatureMapping maps a role to a feature
-	RoleFeatureMapping map[string]string `mapstructure:"role_feature_mapping"`
+	// MembershipFeatureMapping maps a membership to a feature
+	MembershipFeatureMapping map[string]string `mapstructure:"membership_feature_mapping"`
 }
 
-// GetFeaturesForRoles returns the features associated with the roles in the context
-func (fc *FeaturesConfig) GetFeaturesForRoles(ctx context.Context) []string {
-	roles := extractRolesFromContext(ctx)
+// GetFeaturesForMemberships returns the features associated with the memberships in the context
+func (fc *FeaturesConfig) GetFeaturesForMemberships(ctx context.Context) []string {
+	memberships := extractMembershipsFromContext(ctx)
 
 	var features []string
-	for _, role := range roles {
-		if feature, ok := fc.RoleFeatureMapping[role]; ok {
+	for _, m := range memberships {
+		if feature, ok := fc.MembershipFeatureMapping[m]; ok {
 			features = append(features, feature)
 		}
 	}
@@ -29,25 +29,25 @@ func (fc *FeaturesConfig) GetFeaturesForRoles(ctx context.Context) []string {
 	return features
 }
 
-// extractRolesFromContext extracts roles from the JWT in the context.
-// Returns empty slice if no roles are found.
-func extractRolesFromContext(ctx context.Context) []string {
-	realmAccess, ok := jwt.GetUserClaimFromContext[map[string]interface{}](ctx, "realm_access")
+// extractMembershipsFromContext extracts memberships from the JWT in the context.
+// Returns empty slice if no memberships are found.
+func extractMembershipsFromContext(ctx context.Context) []string {
+	realmAccess, ok := jwt.GetUserClaimFromContext[map[string]any](ctx, "realm_access")
 	if !ok {
 		return nil
 	}
 
-	rolesInterface, ok := realmAccess["roles"].([]interface{})
+	rawMemberships, ok := realmAccess["roles"].([]any)
 	if !ok {
 		return nil
 	}
 
-	roles := make([]string, len(rolesInterface))
-	for i, role := range rolesInterface {
-		if roleStr, ok := role.(string); ok {
-			roles[i] = roleStr
+	memberships := make([]string, len(rawMemberships))
+	for i, membership := range rawMemberships {
+		if membershipStr, ok := membership.(string); ok {
+			memberships[i] = membershipStr
 		}
 	}
 
-	return roles
+	return memberships
 }

--- a/pkg/config/server/features.go
+++ b/pkg/config/server/features.go
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright 2024 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mindersec/minder/internal/auth/jwt"
+)
+
+// FeaturesConfig is the configuration for the features
+type FeaturesConfig struct {
+	RoleFeatureMapping map[string]string `mapstructure:"role_feature_mapping"`
+}
+
+// GetFeaturesForRoles returns the features associated with the roles in the context
+func (fc *FeaturesConfig) GetFeaturesForRoles(ctx context.Context) ([]string, error) {
+	roles, err := extractRolesFromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error extracting roles: %v", err)
+	}
+
+	var features []string
+	for _, role := range roles {
+		if feature, ok := fc.RoleFeatureMapping[role]; ok {
+			features = append(features, feature)
+		}
+	}
+	return features, nil
+}
+
+// extractRolesFromContext extracts roles from the JWT in the context
+func extractRolesFromContext(ctx context.Context) ([]string, error) {
+	var realmAccess map[string]interface{}
+	if claim, ok := jwt.GetUserClaimFromContext[map[string]interface{}](ctx, "realm_access"); ok {
+		realmAccess = claim
+	} else {
+		return nil, fmt.Errorf("realm_access claim not found")
+	}
+
+	var roles []string
+	if rolesInterface, ok := realmAccess["roles"].([]interface{}); ok {
+		for _, role := range rolesInterface {
+			if roleStr, ok := role.(string); ok {
+				roles = append(roles, roleStr)
+			}
+		}
+	} else {
+		return nil, fmt.Errorf("roles not found in realm_access")
+	}
+
+	return roles, nil
+}

--- a/pkg/config/server/features.go
+++ b/pkg/config/server/features.go
@@ -37,13 +37,13 @@ func extractMembershipsFromContext(ctx context.Context) []string {
 		return nil
 	}
 
-	membershipsInterface, ok := realmAccess["roles"].([]any)
+	rawMemberships, ok := realmAccess["roles"].([]any)
 	if !ok {
 		return nil
 	}
 
-	memberships := make([]string, len(membershipsInterface))
-	for i, membership := range membershipsInterface {
+	memberships := make([]string, len(rawMemberships))
+	for i, membership := range rawMemberships {
 		if membershipStr, ok := membership.(string); ok {
 			memberships[i] = membershipStr
 		}

--- a/pkg/config/server/features.go
+++ b/pkg/config/server/features.go
@@ -5,22 +5,19 @@ package server
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/mindersec/minder/internal/auth/jwt"
 )
 
 // FeaturesConfig is the configuration for the features
 type FeaturesConfig struct {
+	// RoleFeatureMapping maps a role to a feature
 	RoleFeatureMapping map[string]string `mapstructure:"role_feature_mapping"`
 }
 
 // GetFeaturesForRoles returns the features associated with the roles in the context
-func (fc *FeaturesConfig) GetFeaturesForRoles(ctx context.Context) ([]string, error) {
-	roles, err := extractRolesFromContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("error extracting roles: %v", err)
-	}
+func (fc *FeaturesConfig) GetFeaturesForRoles(ctx context.Context) []string {
+	roles := extractRolesFromContext(ctx)
 
 	var features []string
 	for _, role := range roles {
@@ -28,28 +25,29 @@ func (fc *FeaturesConfig) GetFeaturesForRoles(ctx context.Context) ([]string, er
 			features = append(features, feature)
 		}
 	}
-	return features, nil
+
+	return features
 }
 
-// extractRolesFromContext extracts roles from the JWT in the context
-func extractRolesFromContext(ctx context.Context) ([]string, error) {
-	var realmAccess map[string]interface{}
-	if claim, ok := jwt.GetUserClaimFromContext[map[string]interface{}](ctx, "realm_access"); ok {
-		realmAccess = claim
-	} else {
-		return nil, fmt.Errorf("realm_access claim not found")
+// extractRolesFromContext extracts roles from the JWT in the context.
+// Returns empty slice if no roles are found.
+func extractRolesFromContext(ctx context.Context) []string {
+	realmAccess, ok := jwt.GetUserClaimFromContext[map[string]interface{}](ctx, "realm_access")
+	if !ok {
+		return nil
 	}
 
-	var roles []string
-	if rolesInterface, ok := realmAccess["roles"].([]interface{}); ok {
-		for _, role := range rolesInterface {
-			if roleStr, ok := role.(string); ok {
-				roles = append(roles, roleStr)
-			}
+	rolesInterface, ok := realmAccess["roles"].([]interface{})
+	if !ok {
+		return nil
+	}
+
+	roles := make([]string, len(rolesInterface))
+	for i, role := range rolesInterface {
+		if roleStr, ok := role.(string); ok {
+			roles[i] = roleStr
 		}
-	} else {
-		return nil, fmt.Errorf("roles not found in realm_access")
 	}
 
-	return roles, nil
+	return roles
 }

--- a/pkg/config/server/features.go
+++ b/pkg/config/server/features.go
@@ -19,9 +19,9 @@ type FeaturesConfig struct {
 func (fc *FeaturesConfig) GetFeaturesForMemberships(ctx context.Context) []string {
 	memberships := extractMembershipsFromContext(ctx)
 
-	var features []string
+	features := make([]string, 0, len(memberships))
 	for _, m := range memberships {
-		if feature, ok := fc.MembershipFeatureMapping[m]; ok {
+		if feature := fc.MembershipFeatureMapping[m]; feature != "" {
 			features = append(features, feature)
 		}
 	}
@@ -42,10 +42,10 @@ func extractMembershipsFromContext(ctx context.Context) []string {
 		return nil
 	}
 
-	memberships := make([]string, len(rawMemberships))
-	for i, membership := range rawMemberships {
+	memberships := make([]string, 0, len(rawMemberships))
+	for _, membership := range rawMemberships {
 		if membershipStr, ok := membership.(string); ok {
-			memberships[i] = membershipStr
+			memberships = append(memberships, membershipStr)
 		}
 	}
 

--- a/pkg/config/server/features.go
+++ b/pkg/config/server/features.go
@@ -37,13 +37,13 @@ func extractMembershipsFromContext(ctx context.Context) []string {
 		return nil
 	}
 
-	rawMemberships, ok := realmAccess["roles"].([]any)
+	membershipsInterface, ok := realmAccess["roles"].([]any)
 	if !ok {
 		return nil
 	}
 
-	memberships := make([]string, len(rawMemberships))
-	for i, membership := range rawMemberships {
+	memberships := make([]string, len(membershipsInterface))
+	for i, membership := range membershipsInterface {
 		if membershipStr, ok := membership.(string); ok {
 			memberships[i] = membershipStr
 		}


### PR DESCRIPTION
# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

This PR adds the functionality of automatically creating entitlements records for new projects. This will be done for both project creation paths - parent and sub-projects. 

The process is as follows:

1) In the config we have (e.g.:)
```
features:
  role_feature_mapping:
    stacklok-employees: "stacklok"
    default-roles-stacklok: "default"
    offline_access: "offline"
```

2) From the user's JWT, we get Keycloak-related data in the form of:
```
  "realm_access": {
    "roles": [
      "stacklok-employees",
      "default-roles-stacklok",
      "offline_access",
      "uma_authorization"
    ]
  },
```
3) For each of the three features (stacklok, default, offline), a new entitlement record will be created, mapping the ID of the newly created project.

This not only introduces flexibility in setting up Minder by simply adjusting a config mapping but also helps have separate configurations for each environment and adequate telemetry data at the time of creation instead of aggregating and analysing batched data periodically.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

Tested locally and with updated Unit tests.

![Screenshot 2024-11-14 at 15 54 34](https://github.com/user-attachments/assets/e7c22a88-d585-4d88-bb3d-00aabe1b2d40)
![Screenshot 2024-11-14 at 15 54 37](https://github.com/user-attachments/assets/aef2c824-5c99-400a-949a-d9f5dfe3dcad)
![Screenshot 2024-11-14 at 15 54 41](https://github.com/user-attachments/assets/6d9e6f88-dde1-4fec-934e-a9c2b4baccd0)


# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
