### PR TITLE
Decouple Trusty engine from Trusty SDK structs.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -381,7 +381,7 @@ require (
 	golang.org/x/mod v0.22.0
 	golang.org/x/net v0.31.0 // indirect
 	golang.org/x/sys v0.27.0 // indirect
-	golang.org/x/text v0.20.0 // indirect
+	golang.org/x/text v0.20.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241104194629-dd2ea8efbc28 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/internal/engine/eval/trusty/actions_test.go
+++ b/internal/engine/eval/trusty/actions_test.go
@@ -7,7 +7,6 @@ package trusty
 import (
 	"testing"
 
-	trustytypes "github.com/stacklok/trusty-sdk-go/pkg/v1/types"
 	"github.com/stretchr/testify/require"
 
 	v1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
@@ -26,28 +25,25 @@ func TestBuildProvenanceStruct(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
 		name     string
-		sut      *trustytypes.Reply
+		sut      *trustyReport
 		mustNil  bool
 		expected *templateProvenance
 	}{
 		{
 			name: "full-response",
-			sut: &trustytypes.Reply{
-				Provenance: &trustytypes.Provenance{
-					Score: 8.0,
-					Description: trustytypes.ProvenanceDescription{
-						Historical: trustytypes.HistoricalProvenance{
-							Tags:     10,
-							Common:   8,
-							Overlap:  80,
-							Versions: 10,
-						},
-						Sigstore: trustytypes.SigstoreProvenance{
-							Issuer:           "CN=sigstore-intermediate,O=sigstore.dev",
-							Workflow:         ".github/workflows/build_and_deploy.yml",
-							SourceRepository: "https://github.com/vercel/next.js",
-							Transparency:     "https://search.sigstore.dev/?logIndex=88381843",
-						},
+			sut: &trustyReport{
+				Provenance: &provenance{
+					Historical: &historicalProvenance{
+						Tags:     10,
+						Common:   8,
+						Overlap:  80,
+						Versions: 10,
+					},
+					Sigstore: &sigstoreProvenance{
+						Issuer:           "CN=sigstore-intermediate,O=sigstore.dev",
+						Workflow:         ".github/workflows/build_and_deploy.yml",
+						SourceRepository: "https://github.com/vercel/next.js",
+						RekorURI:         "https://search.sigstore.dev/?logIndex=88381843",
 					},
 				},
 			},
@@ -68,16 +64,13 @@ func TestBuildProvenanceStruct(t *testing.T) {
 		},
 		{
 			name: "only-historical",
-			sut: &trustytypes.Reply{
-				Provenance: &trustytypes.Provenance{
-					Score: 8.0,
-					Description: trustytypes.ProvenanceDescription{
-						Historical: trustytypes.HistoricalProvenance{
-							Tags:     10,
-							Common:   8,
-							Overlap:  80,
-							Versions: 10,
-						},
+			sut: &trustyReport{
+				Provenance: &provenance{
+					Historical: &historicalProvenance{
+						Tags:     10,
+						Common:   8,
+						Overlap:  80,
+						Versions: 10,
 					},
 				},
 			},
@@ -92,16 +85,13 @@ func TestBuildProvenanceStruct(t *testing.T) {
 		},
 		{
 			name: "only-sigstore",
-			sut: &trustytypes.Reply{
-				Provenance: &trustytypes.Provenance{
-					Score: 8.0,
-					Description: trustytypes.ProvenanceDescription{
-						Sigstore: trustytypes.SigstoreProvenance{
-							Issuer:           "CN=sigstore-intermediate,O=sigstore.dev",
-							Workflow:         ".github/workflows/build_and_deploy.yml",
-							SourceRepository: "https://github.com/vercel/next.js",
-							Transparency:     "https://search.sigstore.dev/?logIndex=88381843",
-						},
+			sut: &trustyReport{
+				Provenance: &provenance{
+					Sigstore: &sigstoreProvenance{
+						Issuer:           "CN=sigstore-intermediate,O=sigstore.dev",
+						Workflow:         ".github/workflows/build_and_deploy.yml",
+						SourceRepository: "https://github.com/vercel/next.js",
+						RekorURI:         "https://search.sigstore.dev/?logIndex=88381843",
 					},
 				},
 			},
@@ -122,7 +112,7 @@ func TestBuildProvenanceStruct(t *testing.T) {
 		},
 		{
 			name:    "no-provenance",
-			sut:     &trustytypes.Reply{},
+			sut:     &trustyReport{},
 			mustNil: true,
 		},
 	} {


### PR DESCRIPTION
# Summary

This change aims to limit the impact of changes deriving from Trusty SDK to fewer lines of code. Specifically, business logic implemented in Trusty evaluation engine looks into the response as returned by the SDK itself, making it harder to move to Trusty API v2.

Note: this change is meant to be bug-compatible with the current Trusty evaluation engine.

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [X] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual testing and unit testing.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [X] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
