### PR TITLE
Migrate trusty eval engine to Trusty v2 API.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/sqlc-dev/pqtype v0.3.0
 	github.com/stacklok/frizbee v0.1.4
-	github.com/stacklok/trusty-sdk-go v0.2.2
+	github.com/stacklok/trusty-sdk-go v0.2.3-0.20241121160719-089f44e88687
 	github.com/std-uritemplate/std-uritemplate/go/v2 v2.0.1
 	github.com/stretchr/testify v1.10.0
 	github.com/styrainc/regal v0.29.2
@@ -382,7 +382,7 @@ require (
 	golang.org/x/mod v0.22.0
 	golang.org/x/net v0.31.0 // indirect
 	golang.org/x/sys v0.27.0 // indirect
-	golang.org/x/text v0.20.0
+	golang.org/x/text v0.20.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241118233622-e639e219e697 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1019,8 +1019,8 @@ github.com/sqlc-dev/pqtype v0.3.0 h1:b09TewZ3cSnO5+M1Kqq05y0+OjqIptxELaSayg7bmqk
 github.com/sqlc-dev/pqtype v0.3.0/go.mod h1:oyUjp5981ctiL9UYvj1bVvCKi8OXkCa0u645hce7CAs=
 github.com/stacklok/frizbee v0.1.4 h1:00v6/2HBmwzNdOyVAP4e1isOeUAIWTlb5eggoNUpHmk=
 github.com/stacklok/frizbee v0.1.4/go.mod h1:rFA90VkGFYLb7qCiUniAihmkgXfZAj2BnfF6jR8Csro=
-github.com/stacklok/trusty-sdk-go v0.2.2 h1:55B2DrneLYZXxBaNEeyRMGac7mj+pFbrKomx/hSxUyI=
-github.com/stacklok/trusty-sdk-go v0.2.2/go.mod h1:BbXNVVT32meuxyJuO4pmXRzVPjc/9AXob2sBbOPiKpk=
+github.com/stacklok/trusty-sdk-go v0.2.3-0.20241121160719-089f44e88687 h1:TIZiO871n9V6sSN+bKsG5SwQ4ZHwGtxcmfcL3siimcY=
+github.com/stacklok/trusty-sdk-go v0.2.3-0.20241121160719-089f44e88687/go.mod h1:QR01jLW/yfwcXY38dwDpgeEjVc2MAR1LycH1fXtoSXs=
 github.com/std-uritemplate/std-uritemplate/go/v2 v2.0.1 h1:/m2cTZHpqgofDsrwPqsASI6fSNMNhb+9EmUYtHEV2Uk=
 github.com/std-uritemplate/std-uritemplate/go/v2 v2.0.1/go.mod h1:Z5KcoM0YLC7INlNhEezeIZ0TZNYf7WSNO0Lvah4DSeQ=
 github.com/stoewer/go-strcase v1.3.0 h1:g0eASXYtp+yvN9fK8sH94oCIk0fau9uV1/ZdJ0AVEzs=

--- a/internal/engine/eval/trusty/actions.go
+++ b/internal/engine/eval/trusty/actions.go
@@ -323,8 +323,9 @@ func (sph *summaryPrHandler) generateSummary() (string, error) {
 			// Since (1) we don't have score anymore, and
 			// (2) we don't suggest malicious packages, I
 			// suggest getting rid of this check
-			// altogether.
-			if altData.Score != nil && *altData.Score != 0 && *altData.Score <= lowScorePackages[alternative.Dependency.Name].Score {
+			// altogether and always report all available
+			// alternatives.
+			if comparePackages(altData, lowScorePackages[alternative.Dependency.Name]) == worse {
 				continue
 			}
 
@@ -346,6 +347,23 @@ func (sph *summaryPrHandler) generateSummary() (string, error) {
 	}
 
 	return sph.compileTemplate(malicious, lowScorePackages)
+}
+
+type packageComparison int
+
+const (
+	better packageComparison = iota
+	worse
+)
+
+// comparePackages compares two packages to determine whether the
+// first argument is better or worse than the second one. It does so
+// by checking Trusty scores.
+func comparePackages(alt alternative, examined templatePackage) packageComparison {
+	if alt.Score != nil && *alt.Score != 0 && *alt.Score <= examined.Score {
+		return worse
+	}
+	return better
 }
 
 // buildProvenanceStruct builds the provenance data structure for the PR template

--- a/internal/engine/eval/trusty/trusty_test.go
+++ b/internal/engine/eval/trusty/trusty_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/rs/zerolog"
+	trustytypes "github.com/stacklok/trusty-sdk-go/pkg/v2/types"
 	"github.com/stretchr/testify/require"
 
 	evalerrors "github.com/mindersec/minder/internal/engine/errors"
@@ -341,41 +342,42 @@ func TestClassifyDependency(t *testing.T) {
 
 func TestMakeScoreComponents(t *testing.T) {
 	t.Parallel()
+	typ := trustytypes.ProvenanceTypeVerified
 	for _, tc := range []struct {
 		name     string
-		sut      map[string]any
+		sut      trustytypes.SummaryDescription
 		expected []scoreComponent
 	}{
 		{
 			name: "no-description",
-			sut:  nil,
+			sut:  trustytypes.SummaryDescription{},
 		},
 		{
 			name: "normal-response",
-			sut: map[string]any{
-				"activity":      "a",
-				"activity_user": "b",
-				"provenance":    "c",
-				"activity_repo": "d",
+			sut: trustytypes.SummaryDescription{
+				Activity:       1.0,
+				ActivityUser:   2.0,
+				ActivityRepo:   3.0,
+				ProvenanceType: &typ,
 			},
 			expected: []scoreComponent{
-				{Label: "Package activity", Value: "a"},
-				{Label: "User activity", Value: "b"},
-				{Label: "Provenance", Value: "c"},
-				{Label: "Repository activity", Value: "d"},
+				{Label: "Package activity", Value: 1.0},
+				{Label: "User activity", Value: 2.0},
+				{Label: "Repository activity", Value: 3.0},
+				{Label: "Provenance", Value: "verified_provenance_match"},
 			},
 		},
 		{
 			name: "typosquatting-low",
-			sut: map[string]any{
-				"typosquatting": float64(10),
+			sut: trustytypes.SummaryDescription{
+				TypoSquatting: 10.0,
 			},
 			expected: []scoreComponent{},
 		},
 		{
 			name: "typosquatting-high",
-			sut: map[string]any{
-				"typosquatting": float64(1),
+			sut: trustytypes.SummaryDescription{
+				TypoSquatting: 1,
 			},
 			expected: []scoreComponent{
 				{Label: "Typosquatting", Value: "⚠️ Dependency may be trying to impersonate a well known package"},


### PR DESCRIPTION
# Summary

This change migrates `trusty` evaluation engine to use Trusty v2 API. Most of the changes apply to the intermediate representation we recently added to decouple Trusty from Minder, but some additional changes were required due to some fields becoming optional and nullable.

Note: this change is again meant to be bug-compatible with the current evaluation engine, so we treat the lack of `"score"` as a score of `0`, thus triggering false positives as done by the current engine. The idea is to build on top of this to fix known issues of the engine before migrating it to Data Sources.

Fixes stacklok/minder-stories#77

## Change Type

- [X] Bug fix (resolves an issue without affecting existing features)
- [X] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [X] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Updated unit tests, ran smoke tests locally.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [X] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [X] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
