### PR TITLE
Expect `GetContext` for context v2 resources

### DIFF
--- a/internal/controlplane/common.go
+++ b/internal/controlplane/common.go
@@ -47,7 +47,7 @@ type HasProtoContextV2Compat interface {
 
 // HasProtoContextV2 is an interface that can be implemented by a request
 type HasProtoContextV2 interface {
-	GetContextV2() *pb.ContextV2
+	GetContext() *pb.ContextV2
 }
 
 // HasProtoContext is an interface that can be implemented by a request
@@ -74,13 +74,13 @@ func getProjectFromContextV2Compat(accessor HasProtoContextV2Compat) (uuid.UUID,
 }
 
 func getProjectFromContextV2(accessor HasProtoContextV2) (uuid.UUID, error) {
-	if accessor.GetContextV2() == nil {
+	if accessor.GetContext() == nil {
 		return uuid.Nil, util.UserVisibleError(codes.InvalidArgument, "context cannot be nil")
 	}
 
 	// First check if the context is V2
-	if accessor.GetContextV2() != nil && accessor.GetContextV2().GetProjectId() != "" {
-		return parseProject(accessor.GetContextV2().GetProjectId())
+	if accessor.GetContext() != nil && accessor.GetContext().GetProjectId() != "" {
+		return parseProject(accessor.GetContext().GetProjectId())
 	}
 
 	return uuid.Nil, ErrNoProjectInContext

--- a/internal/controlplane/handlers_authz.go
+++ b/internal/controlplane/handlers_authz.go
@@ -155,7 +155,7 @@ func getProviderFromContext(req any) string {
 		}
 		return req.GetContext().GetProvider()
 	case HasProtoContextV2:
-		return req.GetContextV2().GetProvider()
+		return req.GetContext().GetProvider()
 	case HasProtoContext:
 		return req.GetContext().GetProvider()
 	default:


### PR DESCRIPTION
# Summary

The getter interfaces for v2-context-only resources was incorrect and it
expected us to have a parameter called contextv2. This won't work for
our use-cases.

This fixes the accessor, thus making the compat middleware work.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
