### PR TITLE
Fix the failing auth login command due to missing credentials

### DIFF
--- a/cmd/cli/app/auth/auth_login.go
+++ b/cmd/cli/app/auth/auth_login.go
@@ -26,7 +26,7 @@ $XDG_CONFIG_HOME/minder/credentials.json`,
 }
 
 // LoginCommand is the login subcommand
-func LoginCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grpc.ClientConn) error {
+func LoginCommand(ctx context.Context, cmd *cobra.Command, _ []string, _ *grpc.ClientConn) error {
 	clientConfig, err := config.ReadConfigFromViper[clientconfig.Config](viper.GetViper())
 	if err != nil {
 		return cli.MessageAndError("Unable to read config", err)
@@ -39,6 +39,13 @@ func LoginCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grp
 	if err != nil {
 		return cli.MessageAndError("Error ensuring credentials", err)
 	}
+
+	// Get a connection to the GRPC server after we have the credentials
+	conn, err := cli.GrpcForCommand(cmd, viper.GetViper())
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
 
 	client := minderv1.NewUserServiceClient(conn)
 


### PR DESCRIPTION
# Summary

The following PR fixes the `auth login` command which was failing every time one logs in.

This was caused by the fact that we were passing a gRPC connection through the wrapper which did not had the credentials embedded in it (the login step happens after that). The fix is to ignore the conn from the wrapper and recreate it after the login step is completed. This way the credentials are properly loaded.

Fixes: https://github.com/mindersec/minder/issues/4988

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
