### PR TITLE
Add Trivy's own cache to ignore list

### DIFF
--- a/.trivy.yml
+++ b/.trivy.yml
@@ -13,3 +13,4 @@ scan:
   # Default is empty
   skip-dirs:
     - docs/
+    - ".cache/trivy/"

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,5 +1,0 @@
-# We don't use the affected constructs and thus are not vulnerable.
-CVE-2024-42473
-# We actually use go-tuf v2. v0.7.0 (which is vulnerable) is merely
-# a transitive dependency and we're not affected by the CVE.
-CVE-2024-47534

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,5 @@
+vulnerabilities:
+  - id: CVE-2024-42473
+  # We actually use go-tuf v2. v0.7.0 (which is vulnerable) is merely
+  # a transitive dependency and we're not affected by the CVE.
+  - id: CVE-2024-47534


### PR DESCRIPTION
# Summary

This PR adds trivy's own cache dir to the scan ignore list to fix the flaking trivy scan

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

N/A

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
