### PR TITLE
Add ListRuleTypesReferencesByDataSource db query

### DIFF
--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -2197,6 +2197,21 @@ func (mr *MockStoreMockRecorder) ListRuleTypesByProject(ctx, projectID any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRuleTypesByProject", reflect.TypeOf((*MockStore)(nil).ListRuleTypesByProject), ctx, projectID)
 }
 
+// ListRuleTypesReferencesByDataSource mocks base method.
+func (m *MockStore) ListRuleTypesReferencesByDataSource(ctx context.Context, arg db.ListRuleTypesReferencesByDataSourceParams) ([]db.RuleTypeDataSource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRuleTypesReferencesByDataSource", ctx, arg)
+	ret0, _ := ret[0].([]db.RuleTypeDataSource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRuleTypesReferencesByDataSource indicates an expected call of ListRuleTypesReferencesByDataSource.
+func (mr *MockStoreMockRecorder) ListRuleTypesReferencesByDataSource(ctx, arg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRuleTypesReferencesByDataSource", reflect.TypeOf((*MockStore)(nil).ListRuleTypesReferencesByDataSource), ctx, arg)
+}
+
 // ListTokensToMigrate mocks base method.
 func (m *MockStore) ListTokensToMigrate(ctx context.Context, arg db.ListTokensToMigrateParams) ([]db.ProviderAccessToken, error) {
 	m.ctrl.T.Helper()

--- a/database/query/datasources.sql
+++ b/database/query/datasources.sql
@@ -71,3 +71,9 @@ WHERE project_id = ANY(sqlc.arg(projects)::uuid[]);
 SELECT * FROM data_sources_functions
 WHERE data_source_id = $1 AND project_id = $2;
 
+-- ListRuleTypesReferencesByDataSource retrieves all rule types
+-- referencing a given data source in a given project.
+--
+-- name: ListRuleTypesReferencesByDataSource :many
+SELECT * FROM rule_type_data_sources
+WHERE data_sources_id = $1 AND project_id = $2;

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -225,6 +225,10 @@ type Querier interface {
 	ListRepositoriesByProjectID(ctx context.Context, arg ListRepositoriesByProjectIDParams) ([]Repository, error)
 	ListRuleEvaluationsByProfileId(ctx context.Context, arg ListRuleEvaluationsByProfileIdParams) ([]ListRuleEvaluationsByProfileIdRow, error)
 	ListRuleTypesByProject(ctx context.Context, projectID uuid.UUID) ([]RuleType, error)
+	// ListRuleTypesReferencesByDataSource retrieves all rule types
+	// referencing a given data source in a given project.
+	//
+	ListRuleTypesReferencesByDataSource(ctx context.Context, arg ListRuleTypesReferencesByDataSourceParams) ([]RuleTypeDataSource, error)
 	// When doing a key/algorithm rotation, identify the secrets which need to be
 	// rotated. The criteria for rotation are:
 	// 1) The encrypted_access_token is NULL (this should be removed when we make


### PR DESCRIPTION
# Summary

The following PR adds a query for getting all rule types referencing an existing data source id scoped for a given project.

Ref. https://github.com/mindersec/minder/issues/5045

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
