### PR TITLE
Instantiate data sources from the policy engine

### DIFF
--- a/internal/datasources/service/service.go
+++ b/internal/datasources/service/service.go
@@ -291,6 +291,11 @@ func (d *dataSourceService) BuildDataSourceRegistry(
 	instantiations := rt.GetDef().GetEval().GetDataSources()
 	reg := v1datasources.NewDataSourceRegistry()
 
+	// return early so we don't need to do useless work
+	if len(instantiations) == 0 {
+		return reg, nil
+	}
+
 	stx, err := d.txBuilder(d, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start transaction: %w", err)

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/rs/zerolog"
 
+	datasourceservice "github.com/mindersec/minder/internal/datasources/service"
 	"github.com/mindersec/minder/internal/db"
 	"github.com/mindersec/minder/internal/engine/actions"
 	"github.com/mindersec/minder/internal/engine/actions/alert"
@@ -112,6 +113,8 @@ func (e *executor) EvalEntityEvent(ctx context.Context, inf *entities.EntityInfo
 
 	defer e.releaseLockAndFlush(ctx, inf)
 
+	dssvc := datasourceservice.NewDataSourceService(e.querier)
+
 	entityType := entities.EntityTypeToDB(inf.Type)
 	// Load all the relevant rule type engines for this entity
 	ruleEngineCache, err := rtengine.NewRuleEngineCache(
@@ -121,6 +124,7 @@ func (e *executor) EvalEntityEvent(ctx context.Context, inf *entities.EntityInfo
 		inf.ProjectID,
 		provider,
 		ingestCache,
+		dssvc,
 		eoptions.WithFlagsClient(e.featureFlags),
 	)
 	if err != nil {

--- a/internal/engine/rtengine/cache_test.go
+++ b/internal/engine/rtengine/cache_test.go
@@ -13,21 +13,145 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	mockdssvc "github.com/mindersec/minder/internal/datasources/service/mock"
 	"github.com/mindersec/minder/internal/db"
 	dbf "github.com/mindersec/minder/internal/db/fixtures"
 	"github.com/mindersec/minder/internal/engine/ingestcache"
 	"github.com/mindersec/minder/internal/providers/testproviders"
+	v1datasources "github.com/mindersec/minder/pkg/datasources/v1"
 	rtengine2 "github.com/mindersec/minder/pkg/engine/v1/rtengine"
 )
+
+func TestNewRuleTypeEngineCacheConstructor(t *testing.T) {
+	t.Parallel()
+
+	scenarios := []struct {
+		Name           string
+		DBSetup        dbf.DBMockBuilder
+		DSServiceSetup func(service *mockdssvc.MockDataSourcesService)
+		ExpectedError  string
+	}{
+		{
+			Name: "Returns error when getting parent projects fails",
+			DBSetup: dbf.NewDBMock(func(mock dbf.DBMock) {
+				mock.EXPECT().GetParentProjects(gomock.Any(), gomock.Any()).Return(nil, errTest)
+			}),
+			ExpectedError: "error getting parent projects",
+		},
+		{
+			Name: "Returns error when getting rule types fails",
+			DBSetup: dbf.NewDBMock(func(mock dbf.DBMock) {
+				mock.EXPECT().GetParentProjects(gomock.Any(), gomock.Any()).
+					Return([]uuid.UUID{uuid.New()}, nil)
+				mock.EXPECT().GetRuleTypesByEntityInHierarchy(gomock.Any(), gomock.Any()).
+					Return(nil, errTest)
+			}),
+			ExpectedError: "error while retrieving rule types",
+		},
+		{
+			Name: "Returns error when getting rule type with no def",
+			DBSetup: dbf.NewDBMock(func(mock dbf.DBMock) {
+				mock.EXPECT().GetParentProjects(gomock.Any(), gomock.Any()).
+					Return([]uuid.UUID{uuid.New()}, nil)
+				mock.EXPECT().GetRuleTypesByEntityInHierarchy(gomock.Any(), gomock.Any()).
+					Return([]db.RuleType{{ID: uuid.New()}}, nil)
+			}),
+			ExpectedError: "cannot unmarshal rule type definition",
+		},
+		{
+			Name: "Returns error when building data source registry fails",
+			DBSetup: dbf.NewDBMock(func(mock dbf.DBMock) {
+				hierarchy := []uuid.UUID{uuid.New(), uuid.New()}
+				// Calls from the engine builder itself
+				mock.EXPECT().GetParentProjects(gomock.Any(), gomock.Any()).
+					Return(hierarchy, nil)
+				mock.EXPECT().GetRuleTypesByEntityInHierarchy(gomock.Any(), gomock.Any()).
+					Return([]db.RuleType{{
+						ID:         uuid.New(),
+						ProjectID:  hierarchy[0],
+						Definition: []byte(ruleDefJSON),
+					}}, nil)
+			}),
+			DSServiceSetup: func(service *mockdssvc.MockDataSourcesService) {
+				service.EXPECT().BuildDataSourceRegistry(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, errTest)
+			},
+			ExpectedError: errTest.Error(),
+		},
+		{
+			Name: "Creates rule engine cache",
+			DBSetup: dbf.NewDBMock(func(mock dbf.DBMock) {
+				hierarchy := []uuid.UUID{uuid.New(), uuid.New()}
+				// Calls from the engine builder itself
+				mock.EXPECT().GetParentProjects(gomock.Any(), gomock.Any()).
+					Return(hierarchy, nil)
+				mock.EXPECT().GetRuleTypesByEntityInHierarchy(gomock.Any(), gomock.Any()).
+					Return([]db.RuleType{{
+						ID:         uuid.New(),
+						ProjectID:  hierarchy[0],
+						Definition: []byte(ruleDefJSON),
+					}}, nil)
+			}),
+			DSServiceSetup: func(service *mockdssvc.MockDataSourcesService) {
+				service.EXPECT().BuildDataSourceRegistry(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(v1datasources.NewDataSourceRegistry(), nil)
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			ctx := context.Background()
+
+			dssvc := mockdssvc.NewMockDataSourcesService(ctrl)
+
+			var store db.Store
+			if scenario.DBSetup != nil {
+				store = scenario.DBSetup(ctrl)
+			}
+
+			if scenario.DSServiceSetup != nil {
+				scenario.DSServiceSetup(dssvc)
+			}
+
+			cache, err := NewRuleEngineCache(
+				ctx, store, db.EntitiesRepository, uuid.New(),
+				testproviders.NewGitProvider(nil), ingestcache.NewNoopCache(),
+				dssvc)
+			if scenario.ExpectedError != "" {
+				require.ErrorContains(t, err, scenario.ExpectedError)
+				require.Nil(t, cache)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, cache)
+
+				// Ensure members are not null so we don't fall on the same issue
+				// we had of not initializing them.
+				impl, ok := cache.(*ruleEngineCache)
+				require.True(t, ok)
+				require.NotNil(t, impl.store)
+				require.NotNil(t, impl.provider)
+				require.NotNil(t, impl.ingestCache)
+				require.NotNil(t, impl.engines)
+				require.NotNil(t, impl.dssvc)
+			}
+		})
+	}
+}
 
 func TestGetRuleEngine(t *testing.T) {
 	t.Parallel()
 
 	scenarios := []struct {
-		Name          string
-		Cache         cacheType
-		DBSetup       dbf.DBMockBuilder
-		ExpectedError string
+		Name            string
+		Cache           cacheType
+		DBSetup         dbf.DBMockBuilder
+		ExpectedError   string
+		dsRegistryError error
 	}{
 		{
 			Name:  "Retrieves rule engine from cache",
@@ -62,6 +186,13 @@ func TestGetRuleEngine(t *testing.T) {
 			Cache:   cacheType{},
 			DBSetup: dbf.NewDBMock(withRuleTypeLookup(&ruleType, nil)),
 		},
+		{
+			Name:            "Returns error when building data source registry fails",
+			Cache:           cacheType{},
+			DBSetup:         dbf.NewDBMock(withRuleTypeLookup(&ruleType, nil)),
+			dsRegistryError: errTest,
+			ExpectedError:   errTest.Error(),
+		},
 	}
 
 	for _, scenario := range scenarios {
@@ -77,11 +208,18 @@ func TestGetRuleEngine(t *testing.T) {
 				store = scenario.DBSetup(ctrl)
 			}
 
+			dssvc := mockdssvc.NewMockDataSourcesService(ctrl)
+			reg := v1datasources.NewDataSourceRegistry()
+
+			dssvc.EXPECT().BuildDataSourceRegistry(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(reg, scenario.dsRegistryError).AnyTimes()
+
 			cache := ruleEngineCache{
 				store:       store,
 				provider:    testproviders.NewGitProvider(nil),
 				ingestCache: ingestcache.NewNoopCache(),
 				engines:     scenario.Cache,
+				dssvc:       dssvc,
 			}
 
 			result, err := cache.GetRuleEngine(ctx, ruleTypeID)


### PR DESCRIPTION
# Summary

This hooks data source registration into Minder's policy engine. This is
done by populating individual data source registries into each rule type
engine, which pertains to a single rule type. This way, each rule type
would only have access to the data sources it instantiates.

This also caught a segfault we were unaware of. For some reason, the
builder of the ruletype engine cache was not populating all the needed
members of the struct which would segfault in case the cache did not
have a hit. This fixes that.

Closes: https://github.com/mindersec/minder/issues/5043

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
