### PR TITLE
Validate Data Sources when creating rules.

### DIFF
--- a/internal/controlplane/handlers_ruletype.go
+++ b/internal/controlplane/handlers_ruletype.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	datasourcesvc "github.com/mindersec/minder/internal/datasources/service"
 	"github.com/mindersec/minder/internal/db"
 	"github.com/mindersec/minder/internal/engine/engcontext"
 	"github.com/mindersec/minder/internal/flags"
@@ -175,12 +176,13 @@ func (s *Server) CreateRuleType(
 		return nil, util.UserVisibleError(codes.InvalidArgument, "%s", err)
 	}
 
-	ds := crt.GetRuleType().GetDef().GetEval().GetDataSources()
-	if len(ds) > 0 && !flags.Bool(ctx, s.featureFlags, flags.DataSources) {
-		return nil, status.Errorf(codes.Unavailable, "DataSources feature is disabled")
-	}
-
 	newRuleType, err := db.WithTransaction(s.store, func(qtx db.ExtendQuerier) (*minderv1.RuleType, error) {
+		ruleDS := crt.GetRuleType().GetDef().GetEval().GetDataSources()
+		if err := s.validateDataSources(ctx, projectID, ruleDS, qtx); err != nil {
+			// We expect the error to be a user visible error
+			return nil, err
+		}
+
 		return s.ruleTypes.CreateRuleType(ctx, projectID, uuid.Nil, crt.GetRuleType(), qtx)
 	})
 	if err != nil {
@@ -220,12 +222,13 @@ func (s *Server) UpdateRuleType(
 		return nil, util.UserVisibleError(codes.InvalidArgument, "%s", err)
 	}
 
-	ds := urt.GetRuleType().GetDef().GetEval().GetDataSources()
-	if len(ds) > 0 && !flags.Bool(ctx, s.featureFlags, flags.DataSources) {
-		return nil, status.Errorf(codes.Unavailable, "DataSources feature is disabled")
-	}
-
 	updatedRuleType, err := db.WithTransaction(s.store, func(qtx db.ExtendQuerier) (*minderv1.RuleType, error) {
+		ruleDS := urt.GetRuleType().GetDef().GetEval().GetDataSources()
+		if err := s.validateDataSources(ctx, projectID, ruleDS, qtx); err != nil {
+			// We expect the error to be a user visible error
+			return nil, err
+		}
+
 		return s.ruleTypes.UpdateRuleType(ctx, projectID, uuid.Nil, urt.GetRuleType(), qtx)
 	})
 	if err != nil {
@@ -369,6 +372,37 @@ func validateMarkdown(md string) error {
 			errInvalidRuleType,
 			err,
 		)
+	}
+
+	return nil
+}
+
+func (s *Server) validateDataSources(
+	ctx context.Context,
+	projectID uuid.UUID,
+	ruleDS []*minderv1.DataSourceReference,
+	qtx db.ExtendQuerier,
+) error {
+	// Short circuiting to avoid accessing the database.
+	if len(ruleDS) == 0 {
+		return nil
+	}
+
+	if len(ruleDS) > 0 && !flags.Bool(ctx, s.featureFlags, flags.DataSources) {
+		return status.Errorf(codes.Unavailable, "DataSources feature is disabled")
+	}
+
+	opts := datasourcesvc.ReadBuilder().WithTransaction(qtx)
+	for _, requested := range ruleDS {
+		_, err := s.dataSourcesService.GetByName(
+			ctx,
+			requested.Name,
+			projectID,
+			opts,
+		)
+		if err != nil {
+			return util.UserVisibleError(codes.Internal, "failed retrieving data sources")
+		}
 	}
 
 	return nil

--- a/internal/datasources/service/mock/fixtures/service.go
+++ b/internal/datasources/service/mock/fixtures/service.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Copyright 2024 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package fixtures contains code for creating DataSourceService
+// fixtures and is used in various parts of the code. For testing use
+// only.
+//
+//nolint:all
+package fixtures
+
+import (
+	"errors"
+
+	"github.com/google/uuid"
+	mockdssvc "github.com/mindersec/minder/internal/datasources/service/mock"
+	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
+	"go.uber.org/mock/gomock"
+)
+
+type (
+	DataSourcesSvcMock        = *mockdssvc.MockDataSourcesService
+	DataSourcesSvcMockBuilder = func(*gomock.Controller) DataSourcesSvcMock
+)
+
+func NewDataSourcesServiceMock(opts ...func(mock DataSourcesSvcMock)) DataSourcesSvcMockBuilder {
+	return func(ctrl *gomock.Controller) DataSourcesSvcMock {
+		mock := mockdssvc.NewMockDataSourcesService(ctrl)
+		for _, opt := range opts {
+			opt(mock)
+		}
+		return mock
+	}
+}
+
+var (
+	errDefault = errors.New("error during data sources service operation")
+)
+
+func WithSuccessfulListDataSources(datasources ...*minderv1.DataSource) func(DataSourcesSvcMock) {
+	return func(mock DataSourcesSvcMock) {
+		mock.EXPECT().
+			List(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(datasources, nil)
+	}
+}
+
+func WithFailedListDataSources() func(DataSourcesSvcMock) {
+	return func(mock DataSourcesSvcMock) {
+		mock.EXPECT().
+			List(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, errDefault)
+	}
+}
+
+func WithSuccessfulGetByName(projectID uuid.UUID, datasource *minderv1.DataSource) func(DataSourcesSvcMock) {
+	return func(mock DataSourcesSvcMock) {
+		mock.EXPECT().
+			GetByName(gomock.Any(), datasource.Name, projectID, gomock.Any()).
+			Return(datasource, nil)
+	}
+}
+
+func WithNotFoundGetByName(projectID uuid.UUID) func(DataSourcesSvcMock) {
+	return func(mock DataSourcesSvcMock) {
+		mock.EXPECT().
+			GetByName(gomock.Any(), gomock.Any(), projectID, gomock.Any()).
+			Return(&minderv1.DataSource{}, errDefault)
+	}
+}
+
+func WithFailedGetByName() func(DataSourcesSvcMock) {
+	return func(mock DataSourcesSvcMock) {
+		mock.EXPECT().
+			GetByName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, errDefault)
+	}
+}


### PR DESCRIPTION
# Summary

Rules can now specify a list of data sources names that they need for their evaluation. This change ensures that data sources required by the rule are available when creating the rule.

A similar change is being added in the code path implementing data source deletion ensuring that a data source is not deleted if there exist rules depending on it.

Fixes #5049

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [X] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [X] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Unit tested.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [X] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
