### PR TITLE
Remove `ValidateRuleTypeReferences` from data sources service

### DIFF
--- a/internal/datasources/service/mock/service.go
+++ b/internal/datasources/service/mock/service.go
@@ -147,17 +147,3 @@ func (mr *MockDataSourcesServiceMockRecorder) Update(ctx, ds, opts any) *gomock.
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockDataSourcesService)(nil).Update), ctx, ds, opts)
 }
-
-// ValidateRuleTypeReferences mocks base method.
-func (m *MockDataSourcesService) ValidateRuleTypeReferences(ctx context.Context, rt *v1.RuleType, opts *service.Options) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateRuleTypeReferences", ctx, rt, opts)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ValidateRuleTypeReferences indicates an expected call of ValidateRuleTypeReferences.
-func (mr *MockDataSourcesServiceMockRecorder) ValidateRuleTypeReferences(ctx, rt, opts any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateRuleTypeReferences", reflect.TypeOf((*MockDataSourcesService)(nil).ValidateRuleTypeReferences), ctx, rt, opts)
-}

--- a/internal/datasources/service/service.go
+++ b/internal/datasources/service/service.go
@@ -46,13 +46,6 @@ type DataSourcesService interface {
 	// Note that one cannot delete a data source that is in use by a rule type.
 	Delete(ctx context.Context, id uuid.UUID, project uuid.UUID, opts *Options) error
 
-	// ValidateRuleTypeReferences takes the data source declarations in
-	// a rule type and validates that the data sources are available
-	// in the project hierarchy.
-	//
-	// Note that the rule type already contains project information.
-	ValidateRuleTypeReferences(ctx context.Context, rt *minderv1.RuleType, opts *Options) error
-
 	// BuildDataSourceRegistry bundles up all data sources referenced in the rule type
 	// into a registry.
 	BuildDataSourceRegistry(ctx context.Context, rt *minderv1.RuleType, opts *Options) (*v1datasources.DataSourceRegistry, error)
@@ -368,13 +361,6 @@ func (d *dataSourceService) Delete(
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 	return nil
-}
-
-// nolint:revive // there is a TODO
-func (d *dataSourceService) ValidateRuleTypeReferences(
-	ctx context.Context, rt *minderv1.RuleType, opts *Options) error {
-	//TODO implement me
-	panic("implement me")
 }
 
 // BuildDataSourceRegistry bundles up all data sources referenced in the rule type


### PR DESCRIPTION
# Summary

This was not used and instead the functionality was coded on the rule
type control plane file in https://github.com/mindersec/minder/pull/5068

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
