### PR TITLE
Fix on delete cascade in `rule_type_data_sources`.

### DIFF
--- a/database/migrations/000110_rule_rtype_data_sources_cascading_delete.down.sql
+++ b/database/migrations/000110_rule_rtype_data_sources_cascading_delete.down.sql
@@ -1,0 +1,13 @@
+-- SPDX-FileCopyrightText: Copyright 2024 The Minder Authors
+-- SPDX-License-Identifier: Apache-2.0
+
+BEGIN;
+
+ALTER TABLE rule_type_data_sources
+  DROP CONSTRAINT rule_type_data_sources_rule_type_id_fkey;
+
+ALTER TABLE rule_type_data_sources
+  ADD CONSTRAINT rule_type_data_sources_rule_type_id_fkey
+  FOREIGN KEY (rule_type_id) REFERENCES rule_type(id);
+
+COMMIT;

--- a/database/migrations/000110_rule_rtype_data_sources_cascading_delete.up.sql
+++ b/database/migrations/000110_rule_rtype_data_sources_cascading_delete.up.sql
@@ -1,0 +1,30 @@
+-- SPDX-FileCopyrightText: Copyright 2024 The Minder Authors
+-- SPDX-License-Identifier: Apache-2.0
+
+BEGIN;
+
+-- Generally speaking, given two projects R (root) and A within the
+-- same hierarchy, a rule type defined in project A can reference a
+-- data source defined in project R, and in such cases we want to
+-- prevent admins of project R from deleting the data source without
+-- fixing said rule type in project A (or having someone else fix it
+-- for them), but we still want admins from project A to be able to
+-- delete their rule types without hindrance.
+--
+-- This migration recreates the foreign key constraint to delete rows
+-- from `rule_type_data_sources` when a record is deleted from
+-- `rule_type`.
+--
+-- Note that it is safe to just drop and recreate the constraint as
+-- the previous version prevented the deletion of rule types if they
+-- referenced a data source, so it was not possible to have dangling
+-- records.
+
+ALTER TABLE rule_type_data_sources
+  DROP CONSTRAINT rule_type_data_sources_rule_type_id_fkey;
+
+ALTER TABLE rule_type_data_sources
+  ADD CONSTRAINT rule_type_data_sources_rule_type_id_fkey
+  FOREIGN KEY (rule_type_id) REFERENCES rule_type(id) ON DELETE CASCADE;
+
+COMMIT;


### PR DESCRIPTION
# Summary

This migration recreates the foreign key constraint to delete rows from `rule_type_data_sources` when a record is deleted from `rule_type`.

Note that it is safe to just drop and recreate the constraint as the previous version prevented the deletion of rule types if they referenced a data source, so it was not possible to have dangling records.

## Change Type

- [X] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Tested both
* `minder-server migrate up -n 1 -y`
* `minder-server migrate down -n 1 -y`

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [X] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
