### PR TITLE
Delay data sources initialization, wire ingestion to init

### DIFF
--- a/internal/engine/eval/rego/datasources.go
+++ b/internal/engine/eval/rego/datasources.go
@@ -12,6 +12,7 @@ import (
 	"github.com/open-policy-agent/opa/types"
 
 	v1datasources "github.com/mindersec/minder/pkg/datasources/v1"
+	"github.com/mindersec/minder/pkg/engine/v1/interfaces"
 )
 
 // RegisterDataSources implements the Eval interface.
@@ -21,14 +22,14 @@ func (e *Evaluator) RegisterDataSources(dsr *v1datasources.DataSourceRegistry) {
 
 // buildDataSourceOptions creates an options set from the functions available in
 // a data source registry.
-func buildDataSourceOptions(dsr *v1datasources.DataSourceRegistry) []func(*rego.Rego) {
+func buildDataSourceOptions(res *interfaces.Result, dsr *v1datasources.DataSourceRegistry) []func(*rego.Rego) {
 	opts := []func(*rego.Rego){}
 	if dsr == nil {
 		return opts
 	}
 
 	for key, dsf := range dsr.GetFuncs() {
-		opts = append(opts, buildFromDataSource(key, dsf))
+		opts = append(opts, buildFromDataSource(res, key, dsf))
 	}
 
 	return opts
@@ -37,7 +38,9 @@ func buildDataSourceOptions(dsr *v1datasources.DataSourceRegistry) []func(*rego.
 // buildFromDataSource builds a rego function from a data source function.
 // It takes a DataSourceFuncDef and returns a function that can be used to
 // register the function with the rego engine.
-func buildFromDataSource(key v1datasources.DataSourceFuncKey, dsf v1datasources.DataSourceFuncDef) func(*rego.Rego) {
+func buildFromDataSource(
+	_ *interfaces.Result, key v1datasources.DataSourceFuncKey, dsf v1datasources.DataSourceFuncDef,
+) func(*rego.Rego) {
 	k := normalizeKey(key)
 	return rego.Function1(
 		&rego.Function{

--- a/internal/engine/eval/rego/datasources.go
+++ b/internal/engine/eval/rego/datasources.go
@@ -16,9 +16,22 @@ import (
 
 // RegisterDataSources implements the Eval interface.
 func (e *Evaluator) RegisterDataSources(dsr *v1datasources.DataSourceRegistry) {
-	for key, dsf := range dsr.GetFuncs() {
-		e.regoOpts = append(e.regoOpts, buildFromDataSource(key, dsf))
+	e.datasources = dsr
+}
+
+// buildDataSourceOptions creates an options set from the functions available in
+// a data source registry.
+func buildDataSourceOptions(dsr *v1datasources.DataSourceRegistry) []func(*rego.Rego) {
+	opts := []func(*rego.Rego){}
+	if dsr == nil {
+		return opts
 	}
+
+	for key, dsf := range dsr.GetFuncs() {
+		opts = append(opts, buildFromDataSource(key, dsf))
+	}
+
+	return opts
 }
 
 // buildFromDataSource builds a rego function from a data source function.

--- a/internal/engine/eval/rego/eval.go
+++ b/internal/engine/eval/rego/eval.go
@@ -122,7 +122,7 @@ func (e *Evaluator) Eval(
 	regoFuncOptions = append(regoFuncOptions, instantiateRegoLib(res)...)
 
 	// If the evaluator has data sources defined, expose their functions
-	regoFuncOptions = append(regoFuncOptions, buildDataSourceOptions(e.datasources)...)
+	regoFuncOptions = append(regoFuncOptions, buildDataSourceOptions(res, e.datasources)...)
 
 	// Create the rego object
 	r := e.newRegoFromOptions(


### PR DESCRIPTION
# Summary

This PR modifies the data source init logic to delay the rego function registration until the ingestion results are available.

We also wire the ingestion results to the data source initialization in preparation to pass them to the DS `Call()` method but it stops there to isolate the Call() update into its own PR to discuss (#5093).

Fixes #5088

/cc @JAORMX 

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [ ] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
