### PR TITLE
Pass context with ingestion to data sources

### DIFF
--- a/internal/datasources/rest/handler.go
+++ b/internal/datasources/rest/handler.go
@@ -4,6 +4,7 @@
 package rest
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -96,7 +97,7 @@ func (h *restHandler) ValidateUpdate(obj any) error {
 	}
 }
 
-func (h *restHandler) Call(args any) (any, error) {
+func (h *restHandler) Call(_ context.Context, args any) (any, error) {
 	argsMap, ok := args.(map[string]any)
 	if !ok {
 		return nil, errors.New("args is not a map")

--- a/internal/datasources/rest/handler_test.go
+++ b/internal/datasources/rest/handler_test.go
@@ -4,6 +4,7 @@
 package rest
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -237,7 +238,7 @@ func Test_restHandler_Call(t *testing.T) {
 				headers:      tt.fields.headers,
 				parse:        tt.fields.parse,
 			}
-			got, err := h.Call(tt.args.args)
+			got, err := h.Call(context.Background(), tt.args.args)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/internal/engine/eval/rego/datasources.go
+++ b/internal/engine/eval/rego/datasources.go
@@ -40,7 +40,7 @@ func buildDataSourceOptions(res *interfaces.Result, dsr *v1datasources.DataSourc
 // It takes a DataSourceFuncDef and returns a function that can be used to
 // register the function with the rego engine.
 func buildFromDataSource(
-	_ *interfaces.Result, key v1datasources.DataSourceFuncKey, dsf v1datasources.DataSourceFuncDef,
+	res *interfaces.Result, key v1datasources.DataSourceFuncKey, dsf v1datasources.DataSourceFuncDef,
 ) func(*rego.Rego) {
 	k := normalizeKey(key)
 	return rego.Function1(
@@ -60,7 +60,13 @@ func buildFromDataSource(
 			}
 
 			// Call the data source function
-			ctx := context.Background()
+			ctx := context.WithValue(
+				context.Background(),
+				v1datasources.ContextKey{},
+				v1datasources.Context{
+					Ingest: res,
+				},
+			)
 			ret, err := dsf.Call(ctx, jsonObj)
 			if err != nil {
 				return nil, err

--- a/internal/engine/eval/rego/datasources.go
+++ b/internal/engine/eval/rego/datasources.go
@@ -4,6 +4,7 @@
 package rego
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -59,7 +60,8 @@ func buildFromDataSource(
 			}
 
 			// Call the data source function
-			ret, err := dsf.Call(jsonObj)
+			ctx := context.Background()
+			ret, err := dsf.Call(ctx, jsonObj)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/engine/eval/rego/rego_test.go
+++ b/internal/engine/eval/rego/rego_test.go
@@ -497,7 +497,7 @@ allow {
 	emptyPol := map[string]any{}
 
 	// Matches
-	fdsf.EXPECT().Call(gomock.Any()).Return("foo", nil)
+	fdsf.EXPECT().Call(gomock.Any(), gomock.Any()).Return("foo", nil)
 	err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
 		Object: map[string]any{
 			"data": "foo",
@@ -506,7 +506,7 @@ allow {
 	require.NoError(t, err, "could not evaluate")
 
 	// Doesn't match
-	fdsf.EXPECT().Call(gomock.Any()).Return("bar", nil)
+	fdsf.EXPECT().Call(gomock.Any(), gomock.Any()).Return("bar", nil)
 	err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
 		Object: map[string]any{
 			"data": "bar",

--- a/pkg/datasources/v1/datasources.go
+++ b/pkg/datasources/v1/datasources.go
@@ -4,6 +4,8 @@
 // Package v1 provides the interfaces and types for the data sources.
 package v1
 
+import "context"
+
 //go:generate go run go.uber.org/mock/mockgen -package mock_$GOPACKAGE -destination=./mock/$GOFILE -source=./$GOFILE
 
 const (
@@ -33,7 +35,7 @@ type DataSourceFuncDef interface {
 	// It is the responsibility of the data source implementation to handle the call.
 	// It is also the responsibility of the caller to validate the arguments
 	// before calling the function.
-	Call(args any) (any, error)
+	Call(ctx context.Context, args any) (any, error)
 }
 
 // DataSource is the interface that a data source must implement.
@@ -43,4 +45,7 @@ type DataSourceFuncDef interface {
 type DataSource interface {
 	// GetFuncs returns the functions that the data source provides.
 	GetFuncs() map[DataSourceFuncKey]DataSourceFuncDef
+}
+
+type DataSourceContext struct {
 }

--- a/pkg/datasources/v1/datasources.go
+++ b/pkg/datasources/v1/datasources.go
@@ -4,7 +4,11 @@
 // Package v1 provides the interfaces and types for the data sources.
 package v1
 
-import "context"
+import (
+	"context"
+
+	"github.com/mindersec/minder/pkg/engine/v1/interfaces"
+)
 
 //go:generate go run go.uber.org/mock/mockgen -package mock_$GOPACKAGE -destination=./mock/$GOFILE -source=./$GOFILE
 
@@ -47,5 +51,11 @@ type DataSource interface {
 	GetFuncs() map[DataSourceFuncKey]DataSourceFuncDef
 }
 
-type DataSourceContext struct {
+// ContextKey type to store/retrieve the context
+type ContextKey struct {
+}
+
+// Context encapsulates the context passed to all context function calls
+type Context struct {
+	Ingest *interfaces.Result
 }

--- a/pkg/datasources/v1/mock/datasources.go
+++ b/pkg/datasources/v1/mock/datasources.go
@@ -10,6 +10,7 @@
 package mock_v1
 
 import (
+	context "context"
 	reflect "reflect"
 
 	v1 "github.com/mindersec/minder/pkg/datasources/v1"
@@ -41,18 +42,18 @@ func (m *MockDataSourceFuncDef) EXPECT() *MockDataSourceFuncDefMockRecorder {
 }
 
 // Call mocks base method.
-func (m *MockDataSourceFuncDef) Call(args any) (any, error) {
+func (m *MockDataSourceFuncDef) Call(ctx context.Context, args any) (any, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Call", args)
+	ret := m.ctrl.Call(m, "Call", ctx, args)
 	ret0, _ := ret[0].(any)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Call indicates an expected call of Call.
-func (mr *MockDataSourceFuncDefMockRecorder) Call(args any) *gomock.Call {
+func (mr *MockDataSourceFuncDefMockRecorder) Call(ctx, args any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Call", reflect.TypeOf((*MockDataSourceFuncDef)(nil).Call), args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Call", reflect.TypeOf((*MockDataSourceFuncDef)(nil).Call), ctx, args)
 }
 
 // ValidateArgs mocks base method.


### PR DESCRIPTION
# Summary

This PR builds on https://github.com/mindersec/minder/pull/5091 and modifies the data source `Call()` signature to receive a context in the function call.

We also modify the data sources init to pass the ingestion results which are now available to all data sources drivers.

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

This PR breaks the work in the **last three commits** (ignore the rest, they will be gone after rebasing):

1. fc096ea2f0ff2d81a696c831cc3ece14b4fcf4d0 modifies the data source `Call()` function to take a context 
2. 2663d0071371ab9d0a04de08ef9f0cce766f99f6 regenerates the mocks and updates the tests
3. f138147ea76114425952400df37f3c863e1fad80 initializes the data sources context and passes the ingestion results in it to the data source Call method

Fixes #5089

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [ ] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
