### PR TITLE
datasource :Fix panic in transaction subsystem

### DIFF
--- a/internal/controlplane/handlers_datasource.go
+++ b/internal/controlplane/handlers_datasource.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/mindersec/minder/internal/datasources/service"
 	"github.com/mindersec/minder/internal/engine/engcontext"
 	"github.com/mindersec/minder/internal/flags"
 	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
@@ -71,7 +72,7 @@ func (s *Server) GetDataSourceById(ctx context.Context,
 	}
 
 	// Get the data source by ID
-	ds, err := s.dataSourcesService.GetByID(ctx, dsID, entityCtx.Project.ID, nil)
+	ds, err := s.dataSourcesService.GetByID(ctx, dsID, entityCtx.Project.ID, &service.ReadOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +106,7 @@ func (s *Server) GetDataSourceByName(ctx context.Context,
 	}
 
 	// Get the data source by name
-	ds, err := s.dataSourcesService.GetByName(ctx, dsName, entityCtx.Project.ID, nil)
+	ds, err := s.dataSourcesService.GetByName(ctx, dsName, entityCtx.Project.ID, &service.ReadOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +134,7 @@ func (s *Server) ListDataSources(ctx context.Context,
 	}
 
 	// Get all data sources
-	ret, err := s.dataSourcesService.List(ctx, entityCtx.Project.ID, nil)
+	ret, err := s.dataSourcesService.List(ctx, entityCtx.Project.ID, &service.ReadOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +233,7 @@ func (s *Server) DeleteDataSourceByName(ctx context.Context,
 	}
 
 	// Get the data source id by name
-	ds, err := s.dataSourcesService.GetByName(ctx, dsName, entityCtx.Project.ID, nil)
+	ds, err := s.dataSourcesService.GetByName(ctx, dsName, entityCtx.Project.ID, &service.ReadOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/datasources/service/tx.go
+++ b/internal/datasources/service/tx.go
@@ -22,6 +22,9 @@ type serviceTX interface {
 // This is a handy helper function to optionally begin a transaction if we've already
 // got one.
 func beginTx(d *dataSourceService, opts txGetter) (serviceTX, error) {
+	if opts == nil {
+		opts = &Options{}
+	}
 	if opts.getTransaction() != nil {
 		return &externalTX{q: opts.getTransaction()}, nil
 	}


### PR DESCRIPTION
# Summary

This commit fixes a panic in the data source transaction subsystem when options are nil.

Fixes: https://github.com/mindersec/minder/issues/5113

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

This pr modifies the `beginTx()` in the transaction logic of the data sources to initialize an options set if none is passed. We also make sure that the read-only methods (list/get) retrieve initialize their transactions as read only.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
