### PR TITLE
Use Data Source ID only to check for rule type references

### DIFF
--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -2242,18 +2242,18 @@ func (mr *MockStoreMockRecorder) ListRuleTypesByProject(ctx, projectID any) *gom
 }
 
 // ListRuleTypesReferencesByDataSource mocks base method.
-func (m *MockStore) ListRuleTypesReferencesByDataSource(ctx context.Context, arg db.ListRuleTypesReferencesByDataSourceParams) ([]db.RuleTypeDataSource, error) {
+func (m *MockStore) ListRuleTypesReferencesByDataSource(ctx context.Context, dataSourcesID uuid.UUID) ([]db.RuleTypeDataSource, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRuleTypesReferencesByDataSource", ctx, arg)
+	ret := m.ctrl.Call(m, "ListRuleTypesReferencesByDataSource", ctx, dataSourcesID)
 	ret0, _ := ret[0].([]db.RuleTypeDataSource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListRuleTypesReferencesByDataSource indicates an expected call of ListRuleTypesReferencesByDataSource.
-func (mr *MockStoreMockRecorder) ListRuleTypesReferencesByDataSource(ctx, arg any) *gomock.Call {
+func (mr *MockStoreMockRecorder) ListRuleTypesReferencesByDataSource(ctx, dataSourcesID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRuleTypesReferencesByDataSource", reflect.TypeOf((*MockStore)(nil).ListRuleTypesReferencesByDataSource), ctx, arg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRuleTypesReferencesByDataSource", reflect.TypeOf((*MockStore)(nil).ListRuleTypesReferencesByDataSource), ctx, dataSourcesID)
 }
 
 // ListTokensToMigrate mocks base method.

--- a/database/query/datasources.sql
+++ b/database/query/datasources.sql
@@ -84,7 +84,7 @@ WHERE data_source_id = $1 AND project_id = $2;
 --
 -- name: ListRuleTypesReferencesByDataSource :many
 SELECT * FROM rule_type_data_sources
-WHERE data_sources_id = $1 AND project_id = $2;
+WHERE data_sources_id = $1;
 
 -- AddRuleTypeDataSourceReference adds a link between one rule type
 -- and one data source it uses.

--- a/internal/datasources/service/service.go
+++ b/internal/datasources/service/service.go
@@ -328,10 +328,7 @@ func (d *dataSourceService) Delete(
 	tx := stx.Q()
 
 	// List rule types referencing the data source
-	ret, err := tx.ListRuleTypesReferencesByDataSource(ctx, db.ListRuleTypesReferencesByDataSourceParams{
-		DataSourcesID: id,
-		ProjectID:     project,
-	})
+	ret, err := tx.ListRuleTypesReferencesByDataSource(ctx, id)
 	if err != nil {
 		return fmt.Errorf("failed to list rule types referencing data source %s: %w", id, err)
 	}

--- a/internal/datasources/service/service_test.go
+++ b/internal/datasources/service/service_test.go
@@ -898,10 +898,7 @@ func TestDelete(t *testing.T) {
 			setup: func(args args, mockDB *mockdb.MockStore) {
 				// Mock ListRuleTypesReferencesByDataSource to return empty list
 				mockDB.EXPECT().
-					ListRuleTypesReferencesByDataSource(gomock.Any(), gomock.Eq(db.ListRuleTypesReferencesByDataSourceParams{
-						DataSourcesID: args.id,
-						ProjectID:     args.project,
-					})).
+					ListRuleTypesReferencesByDataSource(gomock.Any(), args.id).
 					Return([]db.RuleTypeDataSource{}, nil)
 
 				// Mock DeleteDataSource to succeed
@@ -924,10 +921,7 @@ func TestDelete(t *testing.T) {
 			setup: func(args args, mockDB *mockdb.MockStore) {
 				// Mock ListRuleTypesReferencesByDataSource to return empty list
 				mockDB.EXPECT().
-					ListRuleTypesReferencesByDataSource(gomock.Any(), gomock.Eq(db.ListRuleTypesReferencesByDataSourceParams{
-						DataSourcesID: args.id,
-						ProjectID:     args.project,
-					})).
+					ListRuleTypesReferencesByDataSource(gomock.Any(), args.id).
 					Return([]db.RuleTypeDataSource{}, nil)
 
 				// Mock DeleteDataSource to return sql.ErrNoRows
@@ -950,10 +944,7 @@ func TestDelete(t *testing.T) {
 			setup: func(args args, mockDB *mockdb.MockStore) {
 				// Mock ListRuleTypesReferencesByDataSource to return non-empty list
 				mockDB.EXPECT().
-					ListRuleTypesReferencesByDataSource(gomock.Any(), gomock.Eq(db.ListRuleTypesReferencesByDataSourceParams{
-						DataSourcesID: args.id,
-						ProjectID:     args.project,
-					})).
+					ListRuleTypesReferencesByDataSource(gomock.Any(), args.id).
 					Return([]db.RuleTypeDataSource{
 						{RuleTypeID: uuid.New()},
 					}, nil)
@@ -970,10 +961,7 @@ func TestDelete(t *testing.T) {
 			setup: func(args args, mockDB *mockdb.MockStore) {
 				// Mock ListRuleTypesReferencesByDataSource to return an error
 				mockDB.EXPECT().
-					ListRuleTypesReferencesByDataSource(gomock.Any(), gomock.Eq(db.ListRuleTypesReferencesByDataSourceParams{
-						DataSourcesID: args.id,
-						ProjectID:     args.project,
-					})).
+					ListRuleTypesReferencesByDataSource(gomock.Any(), args.id).
 					Return(nil, fmt.Errorf("database error"))
 			},
 			wantErr: true,
@@ -988,10 +976,7 @@ func TestDelete(t *testing.T) {
 			setup: func(args args, mockDB *mockdb.MockStore) {
 				// Mock ListRuleTypesReferencesByDataSource to return empty list
 				mockDB.EXPECT().
-					ListRuleTypesReferencesByDataSource(gomock.Any(), gomock.Eq(db.ListRuleTypesReferencesByDataSourceParams{
-						DataSourcesID: args.id,
-						ProjectID:     args.project,
-					})).
+					ListRuleTypesReferencesByDataSource(gomock.Any(), args.id).
 					Return([]db.RuleTypeDataSource{}, nil)
 
 				// Mock DeleteDataSource to return an error

--- a/internal/db/datasources.sql.go
+++ b/internal/db/datasources.sql.go
@@ -358,18 +358,13 @@ func (q *Queries) ListDataSources(ctx context.Context, projects []uuid.UUID) ([]
 
 const listRuleTypesReferencesByDataSource = `-- name: ListRuleTypesReferencesByDataSource :many
 SELECT rule_type_id, data_sources_id, project_id FROM rule_type_data_sources
-WHERE data_sources_id = $1 AND project_id = $2
+WHERE data_sources_id = $1
 `
-
-type ListRuleTypesReferencesByDataSourceParams struct {
-	DataSourcesID uuid.UUID `json:"data_sources_id"`
-	ProjectID     uuid.UUID `json:"project_id"`
-}
 
 // ListRuleTypesReferencesByDataSource retrieves all rule types
 // referencing a given data source in a given project.
-func (q *Queries) ListRuleTypesReferencesByDataSource(ctx context.Context, arg ListRuleTypesReferencesByDataSourceParams) ([]RuleTypeDataSource, error) {
-	rows, err := q.db.QueryContext(ctx, listRuleTypesReferencesByDataSource, arg.DataSourcesID, arg.ProjectID)
+func (q *Queries) ListRuleTypesReferencesByDataSource(ctx context.Context, dataSourcesID uuid.UUID) ([]RuleTypeDataSource, error) {
+	rows, err := q.db.QueryContext(ctx, listRuleTypesReferencesByDataSource, dataSourcesID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -236,7 +236,7 @@ type Querier interface {
 	// ListRuleTypesReferencesByDataSource retrieves all rule types
 	// referencing a given data source in a given project.
 	//
-	ListRuleTypesReferencesByDataSource(ctx context.Context, arg ListRuleTypesReferencesByDataSourceParams) ([]RuleTypeDataSource, error)
+	ListRuleTypesReferencesByDataSource(ctx context.Context, dataSourcesID uuid.UUID) ([]RuleTypeDataSource, error)
 	// When doing a key/algorithm rotation, identify the secrets which need to be
 	// rotated. The criteria for rotation are:
 	// 1) The encrypted_access_token is NULL (this should be removed when we make


### PR DESCRIPTION
# Summary

The project ID belongs to the rule type, so we only check for the data
source ID when checking for references before attempting to delete. This
should be fairly safe as we have already checked the project ID
beforehand.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
