### PR TITLE
Default project ID for data source create/update

### DIFF
--- a/internal/controlplane/handlers_datasource_test.go
+++ b/internal/controlplane/handlers_datasource_test.go
@@ -78,6 +78,10 @@ func TestCreateDataSource(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockStore := mockdb.NewMockStore(ctrl)
+			// project validation
+			mockStore.EXPECT().GetProjectByID(gomock.Any(), projectID).Return(db.Project{
+				ID: projectID,
+			}, nil).AnyTimes()
 
 			mockDataSourceService := mock_service.NewMockDataSourcesService(ctrl)
 			featureClient := &flags.FakeClient{}
@@ -456,6 +460,11 @@ func TestUpdateDataSource(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockStore := mockdb.NewMockStore(ctrl)
+			// project validation
+			mockStore.EXPECT().GetProjectByID(gomock.Any(), projectID).Return(db.Project{
+				ID: projectID,
+			}, nil).AnyTimes()
+
 			mockDataSourceService := mock_service.NewMockDataSourcesService(ctrl)
 			featureClient := &flags.FakeClient{}
 


### PR DESCRIPTION
# Summary

We do some smart stuff in the middleware for the server to determine the
target project in case the user does not specify it. We're not so smart
in persisting that to the create/update requests. This fixes that; Making
creates/updates work without needing to explicitly specify a project ID.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
