### PR TITLE
Get data source string from protobuf struct

### DIFF
--- a/cmd/cli/app/datasource/common.go
+++ b/cmd/cli/app/datasource/common.go
@@ -122,7 +122,7 @@ func appendDataSourcePropertiesToName(ds *minderv1.DataSource) string {
 	name := ds.Name
 	properties := []string{}
 	// add the type property if it is present
-	dType := getDataSourceType(ds)
+	dType := ds.GetDriverType()
 	if dType != "" {
 		properties = append(properties, fmt.Sprintf("type: %s", dType))
 	}
@@ -136,14 +136,6 @@ func appendDataSourcePropertiesToName(ds *minderv1.DataSource) string {
 
 	// return only name otherwise
 	return name
-}
-
-// getDataSourceType returns the type of data source
-func getDataSourceType(ds *minderv1.DataSource) string {
-	if ds.GetRest() != nil {
-		return "REST"
-	}
-	return "Unknown"
 }
 
 // initializeTableForList initializes the table for listing data sources

--- a/cmd/cli/app/datasource/get.go
+++ b/cmd/cli/app/datasource/get.go
@@ -90,7 +90,7 @@ func outputDataSource(cmd *cobra.Command, format string, ds *minderv1.DataSource
 		cmd.Println(out)
 	case app.Table:
 		t := table.New(table.Simple, layouts.Default, []string{"ID", "Name", "Type"})
-		t.AddRow(ds.Id, ds.Name, getDataSourceType(ds))
+		t.AddRow(ds.Id, ds.Name, ds.GetDriverType())
 		t.Render()
 	default:
 		return fmt.Errorf("unsupported output format: %s", format)

--- a/cmd/cli/app/datasource/list.go
+++ b/cmd/cli/app/datasource/list.go
@@ -63,7 +63,7 @@ func listCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grpc
 	case app.Table:
 		t := table.New(table.Simple, layouts.Default, []string{"ID", "Name", "Type"})
 		for _, ds := range resp.GetDataSources() {
-			t.AddRow(ds.Id, ds.Name, getDataSourceType(ds))
+			t.AddRow(ds.Id, ds.Name, ds.GetDriverType())
 		}
 		t.Render()
 	default:

--- a/pkg/api/protobuf/go/minder/v1/datasources.go
+++ b/pkg/api/protobuf/go/minder/v1/datasources.go
@@ -3,6 +3,8 @@
 
 package v1
 
+import v1datasources "github.com/mindersec/minder/pkg/datasources/v1"
+
 // GetContext returns the v2 context from the CreateDataSourceRequest data source.
 func (r *CreateDataSourceRequest) GetContext() *ContextV2 {
 	return r.DataSource.GetContext()
@@ -12,4 +14,18 @@ func (r *CreateDataSourceRequest) GetContext() *ContextV2 {
 // data source.
 func (r *UpdateDataSourceRequest) GetContext() *ContextV2 {
 	return r.DataSource.GetContext()
+}
+
+// GetDriverType returns the string representation of the driver type of the data source.
+func (ds *DataSource) GetDriverType() string {
+	if ds == nil {
+		return ""
+	}
+
+	switch ds.GetDriver().(type) {
+	case *DataSource_Rest:
+		return v1datasources.DataSourceDriverRest
+	default:
+		return "unknown"
+	}
 }


### PR DESCRIPTION
# Summary

This adds a helper function to the data sources protobuf struct to get a
string representation of the driver. This is handy for clients to be
able to render relevant info about data sources.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
