### PR TITLE
Fix dark mode background and API doc colors

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -18,6 +18,10 @@ const redocusaurus = [
         spec: '../pkg/api/openapi/minder/v1/minder.swagger.json',
       },
     ],
+    theme: {
+      primaryColor: '#000000',
+      primaryColorDark: '#b0e0e6',
+    },
   }
 ]
 

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -16,23 +16,20 @@ a {
   text-decoration: underline;
 }
 
-.navbar a {
+.navbar a,
+.menu a,
+.footer a,
+.pagination-nav__link,
+.table-of-contents__link {
   text-decoration: none;
 }
+
 .menu a {
   font-weight: 500;
-  text-decoration: none;
-}
-.footer a {
-  text-decoration: none;
-}
-.pagination-nav__link {
-  text-decoration: none;
 }
 
 .table-of-contents__link {
   text-transform: uppercase;
-  text-decoration: none;
   font-size: 12px;
   font-weight: 700;
 }
@@ -42,11 +39,11 @@ h4 {
 }
 
 :root {
-  --ifm-font-family-base: 'Roboto';  
+  --ifm-font-family-base: 'Roboto';
   --ifm-font-size-base: 15px;
   --ifm-code-font-size: 95%;
   --ifm-navbar-background-color: #303846;
-  --ifm-navbar-link-color: lightgray  ;
+  --ifm-navbar-link-color: lightgray;
   --ifm-navbar-link-hover-color: white;
 }
 
@@ -79,13 +76,13 @@ h4 {
 }
 
 [data-theme='light'] {
-  --ifm-font-family-base: 'Roboto';  
+  --ifm-font-family-base: 'Roboto';
   --ifm-font-size-base: 15px;
   --ifm-color-primary: black;
 }
 
-[data-theme='dark'] body {
-  background-color: black;
+html[data-theme='dark'] {
+  --ifm-background-color: black;
 }
 
 [data-theme='dark'] .hero__subtitle {
@@ -103,6 +100,7 @@ h4 {
 [data-theme='light'] .clean-btn {
   color: lightgray;
 }
+
 [data-theme='light'] .clean-btn:hover {
   background-color: #202020;
 }
@@ -130,7 +128,7 @@ h1 {
 }
 
 [data-theme='dark'] .breadcrumbs__item:not(:last-child):after {
-  content: "›";
+  content: '›';
   color: white;
   margin: 0 0.5rem;
   font-size: 1rem;


### PR DESCRIPTION
# Summary

Docs style fixes:

- Fixes the black background in dark mode, which was only applying to the initial window height and would scroll off leaving the dark gray footer color behind. See screenshots below.
- Sets the primary colors for the Redocusaurus plugin to match the light/dark themes on the rest of the docs.
- Minor consolidation of style classes and formatting of the CSS file.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [x] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

| Background before | Background after |
| :---------------- | :--------------- |
| <img width="1167" alt="image" src="https://github.com/user-attachments/assets/7db28fa6-e6c1-4a87-9e9a-f2ad0d964384"> | <img width="1167" alt="image" src="https://github.com/user-attachments/assets/bca1cf85-c85b-41be-a033-55135b8d54d0"> |

| API docs before | API docs after |
| :-------------- | :------------- |
| <img width="1167" alt="image" src="https://github.com/user-attachments/assets/26d67dbb-be3c-4239-a35a-c0ad1546605e"> | <img width="1167" alt="image" src="https://github.com/user-attachments/assets/c15d8e53-cfb1-46f2-bcdb-f2fccbde9677"> |

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [ ] (N/A) Included tests that validate the fix or feature.
- [ ] (N/A) Checked that related changes are merged.
