### PR TITLE
Simplify propagation of action settings

### DIFF
--- a/internal/engine/actions/alert/alert.go
+++ b/internal/engine/actions/alert/alert.go
@@ -8,7 +8,6 @@ package alert
 import (
 	"context"
 	"fmt"
-	"github.com/mindersec/minder/pkg/profiles/models"
 
 	"github.com/rs/zerolog"
 
@@ -16,6 +15,7 @@ import (
 	"github.com/mindersec/minder/internal/engine/actions/alert/security_advisory"
 	engif "github.com/mindersec/minder/internal/engine/interfaces"
 	pb "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
+	"github.com/mindersec/minder/pkg/profiles/models"
 	provinfv1 "github.com/mindersec/minder/pkg/providers/v1"
 )
 

--- a/internal/engine/actions/alert/alert.go
+++ b/internal/engine/actions/alert/alert.go
@@ -8,6 +8,7 @@ package alert
 import (
 	"context"
 	"fmt"
+	"github.com/mindersec/minder/pkg/profiles/models"
 
 	"github.com/rs/zerolog"
 
@@ -26,6 +27,7 @@ func NewRuleAlert(
 	ctx context.Context,
 	ruletype *pb.RuleType,
 	provider provinfv1.Provider,
+	setting models.ActionOpt,
 ) (engif.Action, error) {
 	alertCfg := ruletype.Def.GetAlert()
 	if alertCfg == nil {
@@ -44,7 +46,8 @@ func NewRuleAlert(
 				Msg("provider is not a GitHub provider. Silently skipping alerts.")
 			return noop.NewNoopAlert(ActionType)
 		}
-		return security_advisory.NewSecurityAdvisoryAlert(ActionType, ruletype, alertCfg.GetSecurityAdvisory(), client)
+		return security_advisory.NewSecurityAdvisoryAlert(
+			ActionType, ruletype, alertCfg.GetSecurityAdvisory(), client, setting)
 	}
 
 	return nil, fmt.Errorf("unknown alert type: %s", alertCfg.GetType())

--- a/internal/engine/actions/alert/noop/noop.go
+++ b/internal/engine/actions/alert/noop/noop.go
@@ -38,7 +38,7 @@ func (_ *Alert) Type() string {
 }
 
 // GetOnOffState returns the off state of the noop engine
-func (_ *Alert) GetOnOffState(_ models.ActionOpt) models.ActionOpt {
+func (_ *Alert) GetOnOffState() models.ActionOpt {
 	return models.ActionOptOff
 }
 
@@ -46,7 +46,6 @@ func (_ *Alert) GetOnOffState(_ models.ActionOpt) models.ActionOpt {
 func (a *Alert) Do(
 	_ context.Context,
 	_ interfaces.ActionCmd,
-	_ models.ActionOpt,
 	_ protoreflect.ProtoMessage,
 	_ interfaces.ActionsParams,
 	_ *json.RawMessage,

--- a/internal/engine/actions/alert/security_advisory/security_advisory_test.go
+++ b/internal/engine/actions/alert/security_advisory/security_advisory_test.go
@@ -90,7 +90,8 @@ func TestSecurityAdvisoryAlert(t *testing.T) {
 			mockClient := mockghclient.NewMockGitHub(ctrl)
 			tt.mockSetup(mockClient)
 
-			saAlert, err := NewSecurityAdvisoryAlert(tt.actionType, &ruleType, &saCfg, mockClient)
+			saAlert, err := NewSecurityAdvisoryAlert(
+				tt.actionType, &ruleType, &saCfg, mockClient, models.ActionOptOn)
 			require.NoError(t, err)
 			require.NotNil(t, saAlert)
 
@@ -103,7 +104,6 @@ func TestSecurityAdvisoryAlert(t *testing.T) {
 			retMeta, err := saAlert.Do(
 				context.Background(),
 				interfaces.ActionCmdOn,
-				models.ActionOptOn,
 				&pbinternal.PullRequest{},
 				evalParams,
 				nil,

--- a/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect_test.go
+++ b/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect_test.go
@@ -321,7 +321,8 @@ func TestBranchProtectionRemediate(t *testing.T) {
 
 			prov, err := testGithubProvider(ghApiUrl)
 			require.NoError(t, err)
-			engine, err := NewGhBranchProtectRemediator(tt.newRemArgs.actionType, tt.newRemArgs.ghp, prov)
+			engine, err := NewGhBranchProtectRemediator(
+				tt.newRemArgs.actionType, tt.newRemArgs.ghp, prov, tt.remArgs.remAction)
 			if tt.wantInitErr {
 				require.Error(t, err, "expected error")
 				return
@@ -343,7 +344,7 @@ func TestBranchProtectionRemediate(t *testing.T) {
 				},
 			}
 
-			retMeta, err := engine.Do(context.Background(), interfaces.ActionCmdOn, tt.remArgs.remAction, tt.remArgs.ent, evalParams, nil)
+			retMeta, err := engine.Do(context.Background(), interfaces.ActionCmdOn, tt.remArgs.ent, evalParams, nil)
 			if tt.wantErr {
 				require.Error(t, err, "expected error")
 				require.Nil(t, retMeta, "expected nil metadata")

--- a/internal/engine/actions/remediate/noop/noop.go
+++ b/internal/engine/actions/remediate/noop/noop.go
@@ -38,7 +38,7 @@ func (_ *Remediator) Type() string {
 }
 
 // GetOnOffState returns the off state of the noop engine
-func (_ *Remediator) GetOnOffState(_ models.ActionOpt) models.ActionOpt {
+func (_ *Remediator) GetOnOffState() models.ActionOpt {
 	return models.ActionOptOff
 }
 
@@ -46,7 +46,6 @@ func (_ *Remediator) GetOnOffState(_ models.ActionOpt) models.ActionOpt {
 func (r *Remediator) Do(
 	_ context.Context,
 	_ interfaces.ActionCmd,
-	_ models.ActionOpt,
 	_ protoreflect.ProtoMessage,
 	_ interfaces.ActionsParams,
 	_ *json.RawMessage,

--- a/internal/engine/actions/remediate/pull_request/pull_request_test.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request_test.go
@@ -621,7 +621,8 @@ func TestPullRequestRemediate(t *testing.T) {
 
 			provider, err := testGithubProvider()
 			require.NoError(t, err)
-			engine, err := NewPullRequestRemediate(tt.newRemArgs.actionType, tt.newRemArgs.prRem, provider)
+			engine, err := NewPullRequestRemediate(
+				tt.newRemArgs.actionType, tt.newRemArgs.prRem, provider, tt.remArgs.remAction)
 			if tt.wantInitErr {
 				require.Error(t, err, "expected error")
 				return
@@ -655,7 +656,6 @@ func TestPullRequestRemediate(t *testing.T) {
 				})
 			retMeta, err := engine.Do(context.Background(),
 				interfaces.ActionCmdOn,
-				tt.remArgs.remAction,
 				tt.remArgs.ent,
 				evalParams,
 				nil)

--- a/internal/engine/actions/remediate/remediate.go
+++ b/internal/engine/actions/remediate/remediate.go
@@ -8,7 +8,6 @@ package remediate
 import (
 	"errors"
 	"fmt"
-	"github.com/mindersec/minder/pkg/profiles/models"
 
 	"github.com/mindersec/minder/internal/engine/actions/remediate/gh_branch_protect"
 	"github.com/mindersec/minder/internal/engine/actions/remediate/noop"
@@ -16,6 +15,7 @@ import (
 	"github.com/mindersec/minder/internal/engine/actions/remediate/rest"
 	engif "github.com/mindersec/minder/internal/engine/interfaces"
 	pb "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
+	"github.com/mindersec/minder/pkg/profiles/models"
 	provinfv1 "github.com/mindersec/minder/pkg/providers/v1"
 )
 

--- a/internal/engine/actions/remediate/remediate.go
+++ b/internal/engine/actions/remediate/remediate.go
@@ -8,6 +8,7 @@ package remediate
 import (
 	"errors"
 	"fmt"
+	"github.com/mindersec/minder/pkg/profiles/models"
 
 	"github.com/mindersec/minder/internal/engine/actions/remediate/gh_branch_protect"
 	"github.com/mindersec/minder/internal/engine/actions/remediate/noop"
@@ -25,6 +26,7 @@ const ActionType engif.ActionType = "remediate"
 func NewRuleRemediator(
 	rt *pb.RuleType,
 	provider provinfv1.Provider,
+	setting models.ActionOpt,
 ) (engif.Action, error) {
 	remediate := rt.Def.GetRemediate()
 	if remediate == nil {
@@ -41,7 +43,7 @@ func NewRuleRemediator(
 		if remediate.GetRest() == nil {
 			return nil, fmt.Errorf("remediations engine missing rest configuration")
 		}
-		return rest.NewRestRemediate(ActionType, remediate.GetRest(), client)
+		return rest.NewRestRemediate(ActionType, remediate.GetRest(), client, setting)
 
 	case gh_branch_protect.RemediateType:
 		client, err := provinfv1.As[provinfv1.GitHub](provider)
@@ -51,7 +53,8 @@ func NewRuleRemediator(
 		if remediate.GetGhBranchProtection() == nil {
 			return nil, fmt.Errorf("remediations engine missing gh_branch_protection configuration")
 		}
-		return gh_branch_protect.NewGhBranchProtectRemediator(ActionType, remediate.GetGhBranchProtection(), client)
+		return gh_branch_protect.NewGhBranchProtectRemediator(
+			ActionType, remediate.GetGhBranchProtection(), client, setting)
 
 	case pull_request.RemediateType:
 		client, err := provinfv1.As[provinfv1.GitHub](provider)
@@ -62,7 +65,8 @@ func NewRuleRemediator(
 			return nil, fmt.Errorf("remediations engine missing pull request configuration")
 		}
 
-		return pull_request.NewPullRequestRemediate(ActionType, remediate.GetPullRequest(), client)
+		return pull_request.NewPullRequestRemediate(
+			ActionType, remediate.GetPullRequest(), client, setting)
 	}
 
 	return nil, fmt.Errorf("unknown remediation type: %s", remediate.GetType())

--- a/internal/engine/actions/remediate/remediate_test.go
+++ b/internal/engine/actions/remediate/remediate_test.go
@@ -5,7 +5,6 @@
 package remediate_test
 
 import (
-	"github.com/mindersec/minder/pkg/profiles/models"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,6 +19,7 @@ import (
 	"github.com/mindersec/minder/internal/providers/telemetry"
 	"github.com/mindersec/minder/internal/providers/testproviders"
 	pb "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
+	"github.com/mindersec/minder/pkg/profiles/models"
 	provifv1 "github.com/mindersec/minder/pkg/providers/v1"
 )
 

--- a/internal/engine/actions/remediate/remediate_test.go
+++ b/internal/engine/actions/remediate/remediate_test.go
@@ -5,6 +5,7 @@
 package remediate_test
 
 import (
+	"github.com/mindersec/minder/pkg/profiles/models"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -117,7 +118,8 @@ func TestNewRuleRemediator(t *testing.T) {
 				provider, err = tt.provider()
 				require.NoError(t, err)
 			}
-			result, err := remediate.NewRuleRemediator(tt.ruleType, provider)
+			result, err := remediate.NewRuleRemediator(
+				tt.ruleType, provider, models.ActionOptOn)
 			if tt.wantError {
 				require.Error(t, err)
 				return

--- a/internal/engine/actions/remediate/rest/rest.go
+++ b/internal/engine/actions/remediate/rest/rest.go
@@ -43,10 +43,15 @@ type Remediator struct {
 	cli              provifv1.REST
 	endpointTemplate *util.SafeTemplate
 	bodyTemplate     *util.SafeTemplate
+	// Setting defines the current action setting. e.g. dry-run, on, off
+	setting models.ActionOpt
 }
 
 // NewRestRemediate creates a new REST rule data ingest engine
-func NewRestRemediate(actionType interfaces.ActionType, restCfg *pb.RestType, cli provifv1.REST) (*Remediator, error) {
+func NewRestRemediate(
+	actionType interfaces.ActionType, restCfg *pb.RestType, cli provifv1.REST,
+	setting models.ActionOpt,
+) (*Remediator, error) {
 	if actionType == "" {
 		return nil, fmt.Errorf("action type cannot be empty")
 	}
@@ -72,6 +77,7 @@ func NewRestRemediate(actionType interfaces.ActionType, restCfg *pb.RestType, cl
 		method:           method,
 		endpointTemplate: endpointTmpl,
 		bodyTemplate:     bodyTmpl,
+		setting:          setting,
 	}, nil
 }
 
@@ -96,15 +102,14 @@ func (_ *Remediator) Type() string {
 }
 
 // GetOnOffState returns the alert action state read from the profile
-func (_ *Remediator) GetOnOffState(actionOpt models.ActionOpt) models.ActionOpt {
-	return models.ActionOptOrDefault(actionOpt, models.ActionOptOff)
+func (r *Remediator) GetOnOffState() models.ActionOpt {
+	return models.ActionOptOrDefault(r.setting, models.ActionOptOff)
 }
 
 // Do perform the remediation
 func (r *Remediator) Do(
 	ctx context.Context,
 	cmd interfaces.ActionCmd,
-	setting models.ActionOpt,
 	entity protoreflect.ProtoMessage,
 	params interfaces.ActionsParams,
 	_ *json.RawMessage,
@@ -137,7 +142,7 @@ func (r *Remediator) Do(
 		Msgf("remediating with endpoint: [%s] and body [%+v]", endpoint.String(), body.String())
 
 	var err error
-	switch setting {
+	switch r.setting {
 	case models.ActionOptOn:
 		err = r.run(ctx, endpoint.String(), body.Bytes())
 	case models.ActionOptDryRun:

--- a/internal/engine/actions/remediate/rest/rest_test.go
+++ b/internal/engine/actions/remediate/rest/rest_test.go
@@ -140,7 +140,8 @@ func TestNewRestRemediate(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			got, err := NewRestRemediate(tt.args.actionType, tt.args.restCfg, restProvider)
+			got, err := NewRestRemediate(
+				tt.args.actionType, tt.args.restCfg, restProvider, models.ActionOptOn)
 			if tt.wantErr {
 				require.Error(t, err, "expected error")
 				require.Nil(t, got, "expected nil")
@@ -372,7 +373,8 @@ func TestRestRemediate(t *testing.T) {
 			defer testServer.Close()
 			provider, err := testGithubProvider(testServer.URL)
 			require.NoError(t, err)
-			engine, err := NewRestRemediate(TestActionTypeValid, tt.newRemArgs.restCfg, provider)
+			engine, err := NewRestRemediate(
+				TestActionTypeValid, tt.newRemArgs.restCfg, provider, tt.remArgs.remAction)
 			require.NoError(t, err, "unexpected error creating remediate engine")
 			require.NotNil(t, engine, "expected non-nil remediate engine")
 
@@ -383,7 +385,8 @@ func TestRestRemediate(t *testing.T) {
 				},
 			}
 
-			retMeta, err := engine.Do(context.Background(), interfaces.ActionCmdOn, tt.remArgs.remAction, tt.remArgs.ent,
+			retMeta, err := engine.Do(
+				context.Background(), interfaces.ActionCmdOn, tt.remArgs.ent,
 				evalParams, nil)
 			if tt.wantErr {
 				require.Error(t, err, "expected error")

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -183,8 +183,6 @@ func (e *executor) evaluateRule(
 		return fmt.Errorf("cannot create rule actions engine: %w", err)
 	}
 
-	evalParams.SetActionsOnOff(actionEngine.GetOnOffState())
-
 	// Update the lock lease at the end of the evaluation
 	defer e.updateLockLease(ctx, *inf.ExecutionID, evalParams)
 

--- a/internal/engine/interfaces/interface.go
+++ b/internal/engine/interfaces/interface.go
@@ -26,8 +26,8 @@ type ActionType string
 type Action interface {
 	Class() ActionType
 	Type() string
-	GetOnOffState(models.ActionOpt) models.ActionOpt
-	Do(ctx context.Context, cmd ActionCmd, setting models.ActionOpt, entity protoreflect.ProtoMessage,
+	GetOnOffState() models.ActionOpt
+	Do(ctx context.Context, cmd ActionCmd, entity protoreflect.ProtoMessage,
 		params ActionsParams, metadata *json.RawMessage) (json.RawMessage, error)
 }
 
@@ -60,13 +60,11 @@ type EvalStatusParams struct {
 	EntityID         uuid.UUID
 	EvalStatusFromDb *db.ListRuleEvaluationsByProfileIdRow
 	evalErr          error
-	actionsOnOff     map[ActionType]models.ActionOpt
 	actionsErr       evalerrors.ActionsError
 	ExecutionID      uuid.UUID
 }
 
 // Ensure EvalStatusParams implements the necessary interfaces
-var _ ActionsParams = (*EvalStatusParams)(nil)
 var _ EvalParamsReader = (*EvalStatusParams)(nil)
 var _ interfaces.ResultSink = (*EvalStatusParams)(nil)
 
@@ -78,16 +76,6 @@ func (e *EvalStatusParams) GetEvalErr() error {
 // SetEvalErr sets the evaluation error
 func (e *EvalStatusParams) SetEvalErr(err error) {
 	e.evalErr = err
-}
-
-// GetActionsOnOff returns the actions' on/off state
-func (e *EvalStatusParams) GetActionsOnOff() map[ActionType]models.ActionOpt {
-	return e.actionsOnOff
-}
-
-// SetActionsOnOff sets the actions' on/off state
-func (e *EvalStatusParams) SetActionsOnOff(actionsOnOff map[ActionType]models.ActionOpt) {
-	e.actionsOnOff = actionsOnOff
 }
 
 // SetActionsErr sets the actions' error
@@ -173,7 +161,6 @@ type EvalParamsReader interface {
 type ActionsParams interface {
 	EvalParamsReader
 	interfaces.ResultSink
-	GetActionsOnOff() map[ActionType]models.ActionOpt
 	GetActionsErr() evalerrors.ActionsError
 	GetEvalErr() error
 	GetEvalStatusFromDb() *db.ListRuleEvaluationsByProfileIdRow

--- a/internal/logger/telemetry_store.go
+++ b/internal/logger/telemetry_store.go
@@ -5,13 +5,13 @@ package logger
 
 import (
 	"context"
-	"github.com/mindersec/minder/internal/engine/actions/alert"
-	"github.com/mindersec/minder/internal/engine/actions/remediate"
 	"slices"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 
+	"github.com/mindersec/minder/internal/engine/actions/alert"
+	"github.com/mindersec/minder/internal/engine/actions/remediate"
 	"github.com/mindersec/minder/internal/engine/errors"
 	"github.com/mindersec/minder/internal/engine/interfaces"
 )

--- a/internal/logger/telemetry_store.go
+++ b/internal/logger/telemetry_store.go
@@ -5,13 +5,13 @@ package logger
 
 import (
 	"context"
+	"github.com/mindersec/minder/internal/engine/actions/alert"
+	"github.com/mindersec/minder/internal/engine/actions/remediate"
 	"slices"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 
-	"github.com/mindersec/minder/internal/engine/actions/alert"
-	"github.com/mindersec/minder/internal/engine/actions/remediate"
 	"github.com/mindersec/minder/internal/engine/errors"
 	"github.com/mindersec/minder/internal/engine/interfaces"
 )
@@ -129,16 +129,19 @@ func (ts *TelemetryStore) AddRuleEval(
 		RuleType:   RuleType{Name: ruleTypeName, ID: evalInfo.GetRule().RuleTypeID},
 		Profile:    Profile{Name: evalInfo.GetProfile().Name, ID: evalInfo.GetProfile().ID},
 		EvalResult: errors.EvalErrorAsString(evalInfo.GetEvalErr()),
-		Actions: map[interfaces.ActionType]ActionEvalData{
-			remediate.ActionType: {
-				State:  evalInfo.GetActionsOnOff()[remediate.ActionType].String(),
-				Result: errors.RemediationErrorAsString(evalInfo.GetActionsErr().RemediateErr),
-			},
-			alert.ActionType: {
-				State:  evalInfo.GetActionsOnOff()[alert.ActionType].String(),
-				Result: errors.AlertErrorAsString(evalInfo.GetActionsErr().AlertErr),
-			},
-		},
+		Actions:    map[interfaces.ActionType]ActionEvalData{},
+	}
+
+	if p := evalInfo.GetProfile(); p != nil {
+		actionCfg := p.ActionConfig
+		red.Actions[remediate.ActionType] = ActionEvalData{
+			State:  actionCfg.Remediate.String(),
+			Result: errors.RemediationErrorAsString(evalInfo.GetActionsErr().RemediateErr),
+		}
+		red.Actions[alert.ActionType] = ActionEvalData{
+			State:  actionCfg.Alert.String(),
+			Result: errors.AlertErrorAsString(evalInfo.GetActionsErr().AlertErr),
+		}
 	}
 
 	ts.Evals = append(ts.Evals, red)

--- a/internal/logger/telemetry_store_test.go
+++ b/internal/logger/telemetry_store_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 
-	"github.com/mindersec/minder/internal/engine/actions/alert"
-	"github.com/mindersec/minder/internal/engine/actions/remediate"
 	enginerr "github.com/mindersec/minder/internal/engine/errors"
 	engif "github.com/mindersec/minder/internal/engine/interfaces"
 	"github.com/mindersec/minder/internal/logger"
@@ -42,12 +40,12 @@ func TestTelemetryStore_Record(t *testing.T) {
 			ep.Profile = &models.ProfileAggregate{
 				Name: "artifact_profile",
 				ID:   testUUID,
+				ActionConfig: models.ActionConfiguration{
+					Remediate: models.ActionOptOff,
+					Alert:     models.ActionOptOn,
+				},
 			}
 			ep.SetEvalErr(enginerr.NewErrEvaluationFailed("evaluation failure reason"))
-			ep.SetActionsOnOff(map[engif.ActionType]models.ActionOpt{
-				alert.ActionType:     models.ActionOptOn,
-				remediate.ActionType: models.ActionOptOff,
-			})
 			ep.SetActionsErr(context.Background(), enginerr.ActionsError{
 				RemediateErr: nil,
 				AlertErr:     enginerr.ErrActionSkipped,
@@ -70,12 +68,12 @@ func TestTelemetryStore_Record(t *testing.T) {
 			ep.Profile = &models.ProfileAggregate{
 				Name: "artifact_profile",
 				ID:   testUUID,
+				ActionConfig: models.ActionConfiguration{
+					Remediate: models.ActionOptOn,
+					Alert:     models.ActionOptOff,
+				},
 			}
 			ep.SetEvalErr(enginerr.NewErrEvaluationFailed("evaluation failure reason"))
-			ep.SetActionsOnOff(map[engif.ActionType]models.ActionOpt{
-				alert.ActionType:     models.ActionOptOff,
-				remediate.ActionType: models.ActionOptOn,
-			})
 			ep.SetActionsErr(context.Background(), enginerr.ActionsError{
 				RemediateErr: nil,
 				AlertErr:     enginerr.ErrActionSkipped,


### PR DESCRIPTION
# Summary

Currently, action settings are passed around via a complex dance of
getter/setter functions that span multiple places in the executor.

However, this is not necessary, as we've already read these settings at
the beginning of execution, and can just set them in place where we need
them.

This simplifies this logic and leverages the aggregate profile structure
to set this. It also enforces the setting as part of the action driver
initiatlization.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
