### PR TITLE
Don't force default branch in deps ingest and fix segfaults

### DIFF
--- a/internal/engine/ingester/deps/deps.go
+++ b/internal/engine/ingester/deps/deps.go
@@ -83,9 +83,9 @@ func (gi *Deps) Ingest(ctx context.Context, ent protoreflect.ProtoMessage, param
 
 func (gi *Deps) ingestRepository(ctx context.Context, repo *pb.Repository, params map[string]any) (*interfaces.Result, error) {
 	var logger = zerolog.Ctx(ctx)
-	userCfg := &Config{
-		Branch: defaultBranch,
-	}
+	// the branch is left unset since we want to auto-discover it
+	// in case it's not explicitly set
+	userCfg := &Config{}
 	if err := mapstructure.Decode(params, userCfg); err != nil {
 		return nil, fmt.Errorf("failed to read dependency ingester configuration from params: %w", err)
 	}
@@ -143,16 +143,16 @@ func (gi *Deps) ingestRepository(ctx context.Context, repo *pb.Repository, param
 	}, nil
 }
 
-func (gi *Deps) getBranch(repo *pb.Repository, branch string) string {
+func (gi *Deps) getBranch(repo *pb.Repository, userConfigBranch string) string {
 	// If the user has specified a branch, use that
-	if branch != "" {
-		return branch
+	if userConfigBranch != "" {
+		return userConfigBranch
 	}
 
 	// If the branch is provided in the rule-type
 	// configuration, use that
-	if gi.cfg.GetRepo().Branch != "" {
-		return gi.cfg.GetRepo().Branch
+	if gi.cfg.GetRepo().GetBranch() != "" {
+		return gi.cfg.GetRepo().GetBranch()
 	}
 	if repo.GetDefaultBranch() != "" {
 		return repo.GetDefaultBranch()


### PR DESCRIPTION
# Summary

This allows us to auto-discover a default branch if the user does not
set it. The previous setup was forcing that we'd always use the
"default" branch, thus bypassing autodiscovery.

It also had segfaults in the case where the repo configuration was not
set.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
