### PR TITLE
Bump components' versions in docker-compose.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,6 @@ Thumbs.db
 .tool-versions
 
 # Minder-specific files
-.ssh/
 cmd/server/__debug_bin
 .resolved-compose.yaml
 .github_client_id/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -125,7 +125,7 @@ services:
 
   keycloak:
     container_name: keycloak_container
-    image: quay.io/keycloak/keycloak:26.0.7
+    image: quay.io/keycloak/keycloak:25.0
     command: ["start-dev"]
     environment:
       KEYCLOAK_ADMIN: admin
@@ -145,7 +145,7 @@ services:
 
   keycloak-config:
     container_name: keycloak_config
-    image: bitnami/keycloak-config-cli:6.2.1
+    image: bitnami/keycloak-config-cli:6.1.6
     entrypoint: ["java", "-jar", "/opt/bitnami/keycloak-config-cli/keycloak-config-cli.jar"]
     environment:
       KEYCLOAK_URL: http://keycloak:8080
@@ -165,7 +165,7 @@ services:
 
   openfga:
     container_name: openfga
-    image: openfga/openfga:v1.8.0
+    image: openfga/openfga:v1.8.1
     command: [
       "run",
       "--playground-port=8085"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -106,7 +106,7 @@ services:
         condition: service_healthy
   postgres:
       container_name: postgres_container
-      image: postgres:16.2-alpine
+      image: postgres:17.2-alpine
       restart: always
       user: postgres
       environment:
@@ -125,7 +125,7 @@ services:
 
   keycloak:
     container_name: keycloak_container
-    image: quay.io/keycloak/keycloak:25.0
+    image: quay.io/keycloak/keycloak:26.0.7
     command: ["start-dev"]
     environment:
       KEYCLOAK_ADMIN: admin
@@ -145,7 +145,7 @@ services:
 
   keycloak-config:
     container_name: keycloak_config
-    image: bitnami/keycloak-config-cli:6.1.6
+    image: bitnami/keycloak-config-cli:6.2.1
     entrypoint: ["java", "-jar", "/opt/bitnami/keycloak-config-cli/keycloak-config-cli.jar"]
     environment:
       KEYCLOAK_URL: http://keycloak:8080
@@ -165,7 +165,7 @@ services:
 
   openfga:
     container_name: openfga
-    image: openfga/openfga:v1.5.0
+    image: openfga/openfga:v1.8.0
     command: [
       "run",
       "--playground-port=8085"
@@ -184,7 +184,7 @@ services:
 
   nats:
     container_name: nats
-    image: nats:2.10.18
+    image: nats:2.10.22
     entrypoint: ["./nats-server"]
     command: ["--http_port", "8222", "-js"]
     healthcheck:
@@ -198,4 +198,3 @@ services:
 networks:
   app_net:
     driver: bridge
-


### PR DESCRIPTION
# Summary

Bump components for local development environment to current version in docker-compose.yaml:
 - postgres to v17.2-alpine (from: https://hub.docker.com/_/postgres)
 - ~keycloak to v26.0.7 (from: https://quay.io/repository/keycloak/keycloak?tab=tags)~
 - ~keycloak-config-cli to v6.2.1 (from: https://hub.docker.com/r/bitnami/keycloak-config-cli)~
 - openfga to v1.8.~0~1 (from: https://hub.docker.com/r/openfga/openfga)
 - nats to v2.10.22 (from: https://hub.docker.com/_/nats)

note re:keycloak: comment https://github.com/mindersec/minder/pull/5152#pullrequestreview-2483980357 below

Bonus: remove redundant entry in .gitignore.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Successfully tested locally:

```
$ make run-docker
Running docker compose down ...
Running docker compose up ...
Building the minder-server image (KO_DOCKER_REPO=ko.local)...
2024/12/05 20:17:57 Using base cgr.dev/chainguard/static:latest@sha256:5ff428f8a48241b93a4174dbbc135a4ffb2381a9e10bdbbc5b9db145645886d5 for github.com/mindersec/minder/cmd/server
2024/12/05 20:17:58 git is in a dirty state
Please check in your pipeline what can be changing the following files:
 M .gitignore
 M docker-compose.yaml
 M docker/minder/Dockerfile
 M docker/reminder/Dockerfile
 M docs/docs/run_minder_server/run_the_server.md
 M go.mod
 M internal/verifier/sigstore/tufroots/tuf-repo.github.com/root.json
 M tools/go.mod

2024/12/05 20:17:58 Building github.com/mindersec/minder/cmd/server for linux/amd64
2024/12/05 20:18:02 Loading ko.local/server:f0d7d43f7c91f9e857e85109c54a9385456d6c5b43375302755741f33682879d
2024/12/05 20:18:02 Loaded ko.local/server:f0d7d43f7c91f9e857e85109c54a9385456d6c5b43375302755741f33682879d
2024/12/05 20:18:02 Adding tag latest
2024/12/05 20:18:02 Added tag latest
[+] Running 8/8
 ✔ Network minder_app_net        Created                                                                                                                                                                                                                                                                                                                                                                                                                                             0.1s 
 ✔ Container keycloak_container  Healthy                                                                                                                                                                                                                                                                                                                                                                                                                                            32.3s 
 ✔ Container openfga             Healthy                                                                                                                                                                                                                                                                                                                                                                                                                                            32.3s 
 ✔ Container nats                Healthy                                                                                                                                                                                                                                                                                                                                                                                                                                            32.3s 
 ✔ Container postgres_container  Healthy                                                                                                                                                                                                                                                                                                                                                                                                                                            32.3s 
 ✔ Container minder_migrate_up   Exited                                                                                                                                                                                                                                                                                                                                                                                                                                             34.2s 
 ✔ Container keycloak_config     Exited                                                                                                                                                                                                                                                                                                                                                                                                                                             32.1s 
 ✔ Container minder_server       Started                                                                                                                                                                                                                                                                                                                                                                                                                                            34.4s 
```

```
$ docker ps --all
CONTAINER ID   IMAGE                                                                              COMMAND                  CREATED          STATUS                      PORTS                                                                                                                             NAMES
19047a7003b8   ko.local/server:f0d7d43f7c91f9e857e85109c54a9385456d6c5b43375302755741f33682879d   "/ko-app/server serv…"   44 seconds ago   Up 9 seconds                0.0.0.0:8080->8080/tcp, :::8080->8080/tcp, 0.0.0.0:8090->8090/tcp, :::8090->8090/tcp, 0.0.0.0:9090->9090/tcp, :::9090->9090/tcp   minder_server
bf0ca19b82f4   bitnami/keycloak-config-cli:6.2.1                                                  "java -jar /opt/bitn…"   44 seconds ago   Exited (0) 15 seconds ago                                                                                                                                     keycloak_config
abfd0b47a593   ko.local/server:f0d7d43f7c91f9e857e85109c54a9385456d6c5b43375302755741f33682879d   "/ko-app/server migr…"   44 seconds ago   Exited (0) 10 seconds ago                                                                                                                                     minder_migrate_up
13e762deaea3   postgres:17.2-alpine                                                               "docker-entrypoint.s…"   44 seconds ago   Up 43 seconds (healthy)     0.0.0.0:5432->5432/tcp, :::5432->5432/tcp                                                                                         postgres_container
b061de0ad640   quay.io/keycloak/keycloak:26.0.7                                                   "/opt/keycloak/bin/k…"   44 seconds ago   Up 43 seconds (healthy)     8443/tcp, 9000/tcp, 0.0.0.0:8081->8080/tcp, :::8081->8080/tcp                                                                     keycloak_container
06ac41bfe625   openfga/openfga:v1.8.0                                                             "/openfga run --play…"   44 seconds ago   Up 43 seconds (healthy)     0.0.0.0:8085->8085/tcp, :::8085->8085/tcp, 0.0.0.0:8082->8080/tcp, :::8082->8080/tcp, 0.0.0.0:8083->8081/tcp, :::8083->8081/tcp   openfga
590e29d5dc70   nats:2.10.22                                                                       "./nats-server --htt…"   44 seconds ago   Up 43 seconds (healthy)     0.0.0.0:4222->4222/tcp, :::4222->4222/tcp, 0.0.0.0:8222->8222/tcp, :::8222->8222/tcp, 6222/tcp                                    nats
```

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
