### PR TITLE
Inform user that datasource is not found when creating rule type

### DIFF
--- a/internal/controlplane/handlers_ruletype.go
+++ b/internal/controlplane/handlers_ruletype.go
@@ -192,7 +192,9 @@ func (s *Server) CreateRuleType(
 		if errors.Is(err, ruletypes.ErrRuleTypeInvalid) {
 			return nil, util.UserVisibleError(codes.InvalidArgument, "invalid rule type definition: %s", err)
 		} else if errors.Is(err, ruletypes.ErrRuleAlreadyExists) {
-			return nil, status.Errorf(codes.AlreadyExists, "rule type %s already exists", crt.RuleType.GetName())
+			return nil, util.UserVisibleError(codes.AlreadyExists, "rule type %s already exists", crt.RuleType.GetName())
+		} else if errors.Is(err, ruletypes.ErrDataSourceNotFound) {
+			return nil, util.UserVisibleError(codes.InvalidArgument, "%s", err.Error())
 		}
 		return nil, status.Errorf(codes.Unknown, "failed to create rule type: %s", err)
 	}

--- a/pkg/ruletypes/service_test.go
+++ b/pkg/ruletypes/service_test.go
@@ -233,14 +233,14 @@ func TestRuleTypeService(t *testing.T) {
 		{
 			Name:          "CreateRuleType with Data Sources not found",
 			RuleType:      newRuleType(withBasicStructure, withDataSources),
-			ExpectedError: "data source not available",
+			ExpectedError: "data source not found",
 			DBSetup:       dbf.NewDBMock(withHierarchyGet, withNotFoundGet, withSuccessfulCreate, withNotFoundGetDataSourcesByName),
 			TestMethod:    create,
 		},
 		{
 			Name:          "UpdateRuleType with Data Sources not found",
 			RuleType:      newRuleType(withBasicStructure, withDataSources),
-			ExpectedError: "data source not available",
+			ExpectedError: "data source not found",
 			DBSetup:       dbf.NewDBMock(withHierarchyGet, withSuccessfulGet, withSuccessfulUpdate, withNotFoundGetDataSourcesByName),
 			TestMethod:    update,
 		},


### PR DESCRIPTION
# Summary

When trying to create a rule type with data sources, we verify that the
data sources must exist. In case they don't the error is now surfaced to
the user.

Closes #5148

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
