### PR TITLE
Enforce defaults in `deps` ingest pull request configuration

### DIFF
--- a/internal/engine/ingester/deps/deps.go
+++ b/internal/engine/ingester/deps/deps.go
@@ -51,6 +51,16 @@ type PullRequestConfig struct {
 	Filter string `json:"filter" yaml:"filter" mapstructure:"filter"`
 }
 
+const (
+	// PullRequestIngestTypeNew is a filter that exposes only new dependencies in the pull request
+	PullRequestIngestTypeNew = "new"
+	// PullRequestIngestTypeNewAndUpdated is a filter that exposes new and updated
+	// dependencies in the pull request
+	PullRequestIngestTypeNewAndUpdated = "new_and_updated"
+	// PullRequestIngestTypeAll is a filter that exposes all dependencies in the pull request
+	PullRequestIngestTypeAll = "all"
+)
+
 // NewDepsIngester creates a new deps rule data ingest engine
 func NewDepsIngester(cfg *pb.DepsType, gitprov provifv1.Git) (*Deps, error) {
 	if gitprov == nil {
@@ -151,13 +161,13 @@ func (gi *Deps) getBranch(repo *pb.Repository, userConfigBranch string) string {
 // ingestTypes returns a sorter function for the given filter type.
 // items which compare equal are skipped in output.
 var ingestTypes = map[string]func(*sbom.Node, *sbom.Node) int{
-	"new": func(base *sbom.Node, updated *sbom.Node) int {
+	PullRequestIngestTypeNew: func(base *sbom.Node, updated *sbom.Node) int {
 		return cmp.Compare(base.GetName(), updated.GetName())
 	},
-	"new_and_updated": func(base *sbom.Node, updated *sbom.Node) int {
+	PullRequestIngestTypeNewAndUpdated: func(base *sbom.Node, updated *sbom.Node) int {
 		return nodeSorter(base, updated)
 	},
-	"all": func(_ *sbom.Node, _ *sbom.Node) int {
+	PullRequestIngestTypeAll: func(_ *sbom.Node, _ *sbom.Node) int {
 		return -1
 	},
 }
@@ -223,10 +233,20 @@ func filterNodes(base []*sbom.Node, updated []*sbom.Node, compare func(*sbom.Nod
 
 func (gi *Deps) ingestPullRequest(
 	ctx context.Context, pr *pbinternal.PullRequest, params map[string]any) (*interfaces.Result, error) {
-	userCfg := &PullRequestConfig{}
+	userCfg := &PullRequestConfig{
+		// We default to new_and_updated for user convenience.
+		Filter: PullRequestIngestTypeNewAndUpdated,
+	}
 	if err := mapstructure.Decode(params, userCfg); err != nil {
 		return nil, fmt.Errorf("failed to read dependency ingester configuration from params: %w", err)
 	}
+
+	// Enforce that the filter is valid if left empty.
+	if userCfg.Filter == "" {
+		userCfg.Filter = PullRequestIngestTypeNewAndUpdated
+	}
+
+	// At this point the user really set a wrong configuration. So, let's error out.
 	if _, ok := ingestTypes[userCfg.Filter]; !ok {
 		return nil, fmt.Errorf("invalid filter type: %s", userCfg.Filter)
 	}


### PR DESCRIPTION
# Summary

If the user would forget to set the parameters, the deps ingest would
fail saying that the filter is invalid. This is not ideal for the user
since we should just set reasonable defaults.

This fixes that!

We now default to `new_and_updated`  if no filter configuration is set.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
