### PR TITLE
Remove short flag from `history purge` command.

### DIFF
--- a/cmd/server/app/history_purge.go
+++ b/cmd/server/app/history_purge.go
@@ -169,6 +169,6 @@ func deleteEvaluationHistory(
 
 func init() {
 	historyCmd.AddCommand(historyPurgeCmd)
-	historyPurgeCmd.Flags().UintP("batch-size", "s", 1000, "Size of the deletion batch")
+	historyPurgeCmd.Flags().UintP("batch-size", "", 1000, "Size of the deletion batch")
 	historyPurgeCmd.Flags().Bool("dry-run", false, "Avoids deleting, printing out details about the operation")
 }


### PR DESCRIPTION
# Summary

The command `minder history purge` supports specifying a custom batch size via `--batch-size/-s` option. The short version `-s` overlaps with the short version of `--db-sslmode`, which is a root-level option.

This change solves the overlap by removing the short option from `minder history purge`.

## Change Type

***Mark the type of change your PR introduces:***

- [X] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual tests.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
