### PR TITLE
Limit http.send in rego evaluation to "normal" public IPs.

### DIFF
--- a/internal/engine/eval/rego/eval.go
+++ b/internal/engine/eval/rego/eval.go
@@ -153,7 +153,7 @@ func (e *Evaluator) Eval(
 	}
 
 	enrichInputWithEntityProps(input, entity)
-	rs, err := pq.Eval(ctx, rego.EvalInput(input))
+	rs, err := pq.Eval(ctx, rego.EvalInput(input), rego.EvalHTTPRoundTripper(LimitedDialer))
 	if err != nil {
 		return nil, fmt.Errorf("error evaluating profile. Might be wrong input: %w", err)
 	}

--- a/internal/engine/eval/rego/http.go
+++ b/internal/engine/eval/rego/http.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2023 The Minder Authors
+// SPDX-FileCopyrightText: Copyright 2025 The Minder Authors
 // SPDX-License-Identifier: Apache-2.0
 
 // Package rego provides the rego rule evaluator
@@ -15,7 +15,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
 )
-
 
 var blockedRequests metric.Int64Counter
 var metricsInit sync.Once

--- a/internal/engine/eval/rego/http.go
+++ b/internal/engine/eval/rego/http.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Copyright 2023 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package rego provides the rego rule evaluator
+package rego
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+
+	"github.com/rs/zerolog"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+)
+
+
+var blockedRequests metric.Int64Counter
+var metricsInit sync.Once
+
+type dialContextFunc = func(ctx context.Context, network, addr string) (net.Conn, error)
+
+// LimitedDialer is an HTTP Dialer (Rego topdowmn.CustomizeRoundTripper) which
+// allows us to limit the destination of dialed requests to block specific
+// network ranges (such as RFC1918 space).  It operates by attempting to dial
+// the requested URL (going through DNS resolution, etc), and then examining
+// the remote IP address via conn.RemoteAddr().
+func LimitedDialer(transport *http.Transport) http.RoundTripper {
+	metricsInit.Do(func() {
+		meter := otel.Meter("minder")
+		var err error
+		blockedRequests, err = meter.Int64Counter(
+			"rego.http.blocked_requests",
+			metric.WithDescription("Number of Rego requests to private addresses blocked during evaluation"),
+		)
+		if err != nil {
+			zerolog.Ctx(context.Background()).Warn().Err(err).Msg("Creating counter for blocked requests failed")
+		}
+	})
+	if transport == nil {
+		var ok bool
+		transport, ok = http.DefaultTransport.(*http.Transport)
+		if !ok {
+			transport = &http.Transport{}
+		}
+	}
+	transport.DialContext = publicOnlyDialer(transport.DialContext)
+	return transport
+}
+
+func publicOnlyDialer(baseDialer dialContextFunc) dialContextFunc {
+	if baseDialer == nil {
+		baseDialer = (&net.Dialer{}).DialContext
+	}
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		conn, err := baseDialer(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		remote, ok := conn.RemoteAddr().(*net.TCPAddr)
+		if !ok {
+			return nil, fmt.Errorf("Remote address is not a TCP address")
+		}
+		if !remote.IP.IsGlobalUnicast() || remote.IP.IsLoopback() || remote.IP.IsPrivate() {
+			// We do not need to lock because blockedRequests is initialized in a sync.Once
+			// which is called before this method
+			if blockedRequests != nil {
+				blockedRequests.Add(ctx, 1)
+			}
+			// Intentionally do not leak address resolution information
+			return nil, fmt.Errorf("remote address is not public")
+		}
+		return conn, err
+	}
+}

--- a/internal/engine/eval/rego/http_test.go
+++ b/internal/engine/eval/rego/http_test.go
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: Copyright 2023 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package rego provides the rego rule evaluator
+package rego_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	engerrors "github.com/mindersec/minder/internal/engine/errors"
+	"github.com/mindersec/minder/internal/engine/eval/rego"
+	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
+	"github.com/mindersec/minder/pkg/engine/v1/interfaces"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimitedDialer(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func (w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		t.Log("FETCHED!")
+		_, _ = w.Write([]byte(`{"ok": 1}`))
+	}))
+	t.Cleanup(ts.Close)
+
+	ruleDef := `
+		package minder
+		import rego.v1
+
+		default allow := false
+		resp := http.send({"url": "%s", "method": "GET", "raise_error": false})
+		allow if {
+		  not resp.error
+		}
+		message := resp.error.message
+		`
+
+	tests := []struct {
+		name string
+		url string
+		wantErr string
+	}{{
+		name: "test blocked fetch by name",
+		url: ts.URL,
+		wantErr: "remote address is not public",
+	},{
+		name: "google.com not blocked",
+		url: "http://www.google.com",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			eval, err := rego.NewRegoEvaluator(
+				&minderv1.RuleType_Definition_Eval_Rego{
+					Type: rego.DenyByDefaultEvaluationType.String(),
+					Def: fmt.Sprintf(ruleDef, tt.url),
+				},
+				nil,
+			)
+			require.NoError(t, err, "could not create evaluator")
+
+			emptyPol := map[string]any{}
+
+			res, err := eval.Eval(context.Background(), emptyPol, nil, &interfaces.Result{})
+
+			if tt.wantErr == "" {
+				require.NoError(t, err, "expected no error")
+				require.NotNil(t, res, "expected a result")
+				return
+			}
+
+			require.Nil(t, res, "expected nil result")
+			require.ErrorIs(t, err, engerrors.ErrEvaluationFailed)
+			detailErr := err.(*engerrors.EvaluationError)
+			require.Contains(t, detailErr.Details(), tt.wantErr)
+		})
+	}
+}

--- a/internal/engine/eval/rego/http_test.go
+++ b/internal/engine/eval/rego/http_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2023 The Minder Authors
+// SPDX-FileCopyrightText: Copyright 2025 The Minder Authors
 // SPDX-License-Identifier: Apache-2.0
 
 // Package rego provides the rego rule evaluator
@@ -11,19 +11,19 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	engerrors "github.com/mindersec/minder/internal/engine/errors"
 	"github.com/mindersec/minder/internal/engine/eval/rego"
 	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
 	"github.com/mindersec/minder/pkg/engine/v1/interfaces"
-	"github.com/stretchr/testify/require"
 )
 
 func TestLimitedDialer(t *testing.T) {
 	t.Parallel()
 
-	ts := httptest.NewServer(http.HandlerFunc(func (w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		t.Log("FETCHED!")
 		_, _ = w.Write([]byte(`{"ok": 1}`))
 	}))
 	t.Cleanup(ts.Close)
@@ -41,16 +41,16 @@ func TestLimitedDialer(t *testing.T) {
 		`
 
 	tests := []struct {
-		name string
-		url string
+		name    string
+		url     string
 		wantErr string
 	}{{
-		name: "test blocked fetch by name",
-		url: ts.URL,
+		name:    "test blocked fetch by name",
+		url:     ts.URL,
 		wantErr: "remote address is not public",
-	},{
+	}, {
 		name: "google.com not blocked",
-		url: "http://www.google.com",
+		url:  "http://www.google.com",
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -59,7 +59,7 @@ func TestLimitedDialer(t *testing.T) {
 			eval, err := rego.NewRegoEvaluator(
 				&minderv1.RuleType_Definition_Eval_Rego{
 					Type: rego.DenyByDefaultEvaluationType.String(),
-					Def: fmt.Sprintf(ruleDef, tt.url),
+					Def:  fmt.Sprintf(ruleDef, tt.url),
 				},
 				nil,
 			)


### PR DESCRIPTION
# Summary

Use a new feature in OPA v1.0.0 to patch the HTTP roundtripper to only send to public IP addresses.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual testing and then added unit tests, then figured out what `raise_error` actually does in `http.send`: https://github.com/open-policy-agent/opa/issues/5805 (hint: it doesn't fail the whole rule and return an error, it just drops that particular branch of evaluation...)

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
