### PR TITLE
Limit allowed redirect URLs from GetAuthorizationURL

### DIFF
--- a/internal/controlplane/handlers_oauth_test.go
+++ b/internal/controlplane/handlers_oauth_test.go
@@ -196,6 +196,7 @@ func TestGetAuthorizationURL(t *testing.T) {
 	githubAppProviderClass := "github-app"
 	nonGithubProviderName := "non-github"
 	projectIdStr := projectID.String()
+	attackerUrl := "https://www.attacker.com/collect/here"
 
 	testCases := []struct {
 		name               string
@@ -231,6 +232,7 @@ func TestGetAuthorizationURL(t *testing.T) {
 
 				if err != nil {
 					t.Errorf("Unexpected error: %v", err)
+					return
 				}
 
 				if res.Url == "" {
@@ -265,6 +267,7 @@ func TestGetAuthorizationURL(t *testing.T) {
 
 				if err != nil {
 					t.Errorf("Unexpected error: %v", err)
+					return
 				}
 
 				if res.Url == "" {
@@ -291,6 +294,24 @@ func TestGetAuthorizationURL(t *testing.T) {
 				assert.Error(t, err, "Expected error in GetAuthorizationURL")
 			},
 
+			expectedStatusCode: codes.InvalidArgument,
+		},
+		{
+			name: "Bad redirect URL",
+			req: &pb.GetAuthorizationURLRequest{
+				Context: &pb.Context{
+					Provider: &githubProviderClass,
+					Project:  &projectIdStr,
+				},
+				Cli:         true,
+				RedirectUrl: &attackerUrl,
+			},
+			buildStubs: func(_ *mockdb.MockStore) {},
+			checkResponse: func(t *testing.T, _ *pb.GetAuthorizationURLResponse, err error) {
+				t.Helper()
+
+				assert.Error(t, err, "Expected error in GetAuthorizationURL")
+			},
 			expectedStatusCode: codes.InvalidArgument,
 		},
 		{
@@ -325,6 +346,7 @@ func TestGetAuthorizationURL(t *testing.T) {
 
 				if err != nil {
 					t.Errorf("Unexpected error: %v", err)
+					return
 				}
 
 				if res.Url == "" {


### PR DESCRIPTION
# Summary

Currently, it is possible to set an arbitrary redirect URL after completing Minder login.  Limit this to localhost (for CLI), or known endpoints in our config.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Added unit tests -- I'm wondering if we should put this behind a configuration option as well for easier rollback if I got something wrong.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
