### PR TITLE
Support data sources in bundles

### DIFF
--- a/internal/controlplane/handlers_datasource.go
+++ b/internal/controlplane/handlers_datasource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mindersec/minder/internal/datasources/service"
 	"github.com/mindersec/minder/internal/engine/engcontext"
 	"github.com/mindersec/minder/internal/flags"
+	"github.com/mindersec/minder/internal/util"
 	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -25,6 +26,14 @@ func (s *Server) CreateDataSource(ctx context.Context,
 		return nil, status.Errorf(codes.Unavailable, "DataSources feature is disabled")
 	}
 
+	entityCtx := engcontext.EntityFromContext(ctx)
+	err := entityCtx.ValidateProject(ctx, s.store)
+	if err != nil {
+		return nil, util.UserVisibleError(codes.InvalidArgument, "error in entity context: %v", err)
+	}
+
+	projectID := entityCtx.Project.ID
+
 	// Get the data source from the request
 	dsReq := in.GetDataSource()
 	if dsReq == nil {
@@ -36,7 +45,7 @@ func (s *Server) CreateDataSource(ctx context.Context,
 	}
 
 	// Process the request
-	ret, err := s.dataSourcesService.Create(ctx, uuid.Nil, dsReq, nil)
+	ret, err := s.dataSourcesService.Create(ctx, projectID, uuid.Nil, dsReq, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -156,6 +165,14 @@ func (s *Server) UpdateDataSource(ctx context.Context,
 		return nil, status.Errorf(codes.Unavailable, "DataSources feature is disabled")
 	}
 
+	entityCtx := engcontext.EntityFromContext(ctx)
+	err := entityCtx.ValidateProject(ctx, s.store)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
+	}
+
+	projectID := entityCtx.Project.ID
+
 	// Get the data source from the request
 	dsReq := in.GetDataSource()
 	if dsReq == nil {
@@ -167,7 +184,7 @@ func (s *Server) UpdateDataSource(ctx context.Context,
 	}
 
 	// Process the request
-	ret, err := s.dataSourcesService.Update(ctx, uuid.Nil, dsReq, nil)
+	ret, err := s.dataSourcesService.Update(ctx, projectID, uuid.Nil, dsReq, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controlplane/handlers_datasource_test.go
+++ b/internal/controlplane/handlers_datasource_test.go
@@ -37,7 +37,7 @@ func TestCreateDataSource(t *testing.T) {
 			setupMocks: func(dsService *mock_service.MockDataSourcesService, featureClient *flags.FakeClient) {
 				featureClient.Data = map[string]interface{}{"data_sources": true}
 				dsService.EXPECT().
-					Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(&minderv1.DataSource{Name: "test-ds"}, nil)
 			},
 			request: &minderv1.CreateDataSourceRequest{
@@ -417,7 +417,7 @@ func TestUpdateDataSource(t *testing.T) {
 			setupMocks: func(dsService *mock_service.MockDataSourcesService, featureClient *flags.FakeClient, _ *mockdb.MockStore) {
 				featureClient.Data = map[string]interface{}{"data_sources": true}
 				dsService.EXPECT().
-					Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(&minderv1.DataSource{Id: dsIDStr, Name: "updated-ds"}, nil)
 			},
 			request: &minderv1.UpdateDataSourceRequest{

--- a/internal/controlplane/handlers_user.go
+++ b/internal/controlplane/handlers_user.go
@@ -114,7 +114,7 @@ func (s *Server) CreateUser(ctx context.Context,
 	}, nil
 }
 
-func (s *Server) claimGitHubInstalls(ctx context.Context, qtx db.Querier) []*db.Project {
+func (s *Server) claimGitHubInstalls(ctx context.Context, qtx db.ExtendQuerier) []*db.Project {
 	ghId, ok := jwt.GetUserClaimFromContext[string](ctx, "gh_id")
 	if !ok || ghId == "" {
 		return nil
@@ -484,7 +484,7 @@ func (s *Server) acceptInvitation(ctx context.Context, userInvite db.GetInvitati
 	return nil
 }
 
-func ensureUser(ctx context.Context, s *Server, store db.Querier) (db.User, error) {
+func ensureUser(ctx context.Context, s *Server, store db.ExtendQuerier) (db.User, error) {
 	sub := jwt.GetUserSubjectFromContext(ctx)
 	if sub == "" {
 		return db.User{}, status.Error(codes.Internal, "failed to get user subject")

--- a/internal/datasources/service/mock/fixtures/service.go
+++ b/internal/datasources/service/mock/fixtures/service.go
@@ -75,3 +75,9 @@ func WithFailedGetByName() func(DataSourcesSvcMock) {
 			Return(nil, errDefault)
 	}
 }
+
+func WithSuccessfulUpsertDataSource(mock DataSourcesSvcMock) {
+	mock.EXPECT().
+		Upsert(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil)
+}

--- a/internal/datasources/service/mock/service.go
+++ b/internal/datasources/service/mock/service.go
@@ -60,18 +60,18 @@ func (mr *MockDataSourcesServiceMockRecorder) BuildDataSourceRegistry(ctx, rt, o
 }
 
 // Create mocks base method.
-func (m *MockDataSourcesService) Create(ctx context.Context, subscriptionID uuid.UUID, ds *v1.DataSource, opts *service.Options) (*v1.DataSource, error) {
+func (m *MockDataSourcesService) Create(ctx context.Context, projectID, subscriptionID uuid.UUID, ds *v1.DataSource, opts *service.Options) (*v1.DataSource, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", ctx, subscriptionID, ds, opts)
+	ret := m.ctrl.Call(m, "Create", ctx, projectID, subscriptionID, ds, opts)
 	ret0, _ := ret[0].(*v1.DataSource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockDataSourcesServiceMockRecorder) Create(ctx, subscriptionID, ds, opts any) *gomock.Call {
+func (mr *MockDataSourcesServiceMockRecorder) Create(ctx, projectID, subscriptionID, ds, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockDataSourcesService)(nil).Create), ctx, subscriptionID, ds, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockDataSourcesService)(nil).Create), ctx, projectID, subscriptionID, ds, opts)
 }
 
 // Delete mocks base method.
@@ -134,16 +134,30 @@ func (mr *MockDataSourcesServiceMockRecorder) List(ctx, project, opts any) *gomo
 }
 
 // Update mocks base method.
-func (m *MockDataSourcesService) Update(ctx context.Context, subscriptionID uuid.UUID, ds *v1.DataSource, opts *service.Options) (*v1.DataSource, error) {
+func (m *MockDataSourcesService) Update(ctx context.Context, projectID, subscriptionID uuid.UUID, ds *v1.DataSource, opts *service.Options) (*v1.DataSource, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", ctx, subscriptionID, ds, opts)
+	ret := m.ctrl.Call(m, "Update", ctx, projectID, subscriptionID, ds, opts)
 	ret0, _ := ret[0].(*v1.DataSource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockDataSourcesServiceMockRecorder) Update(ctx, subscriptionID, ds, opts any) *gomock.Call {
+func (mr *MockDataSourcesServiceMockRecorder) Update(ctx, projectID, subscriptionID, ds, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockDataSourcesService)(nil).Update), ctx, subscriptionID, ds, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockDataSourcesService)(nil).Update), ctx, projectID, subscriptionID, ds, opts)
+}
+
+// Upsert mocks base method.
+func (m *MockDataSourcesService) Upsert(ctx context.Context, projectID, subscriptionID uuid.UUID, ds *v1.DataSource, opts *service.Options) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Upsert", ctx, projectID, subscriptionID, ds, opts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Upsert indicates an expected call of Upsert.
+func (mr *MockDataSourcesServiceMockRecorder) Upsert(ctx, projectID, subscriptionID, ds, opts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upsert", reflect.TypeOf((*MockDataSourcesService)(nil).Upsert), ctx, projectID, subscriptionID, ds, opts)
 }

--- a/internal/datasources/service/service_test.go
+++ b/internal/datasources/service/service_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 var (
+	projectID              = uuid.New()
 	subscriptionID         = uuid.New()
 	validRESTDriverFixture = &minderv1.DataSource_Rest{
 		Rest: &minderv1.RestDataSource{
@@ -554,7 +555,7 @@ func TestCreate(t *testing.T) {
 			}
 			tt.setup(mockStore)
 
-			got, err := svc.Create(context.Background(), tt.args.subscriptionId, tt.args.ds, tt.args.opts)
+			got, err := svc.Create(context.Background(), projectID, tt.args.subscriptionId, tt.args.ds, tt.args.opts)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -1535,7 +1536,7 @@ func TestUpdate(t *testing.T) {
 
 			tt.setup(mockStore)
 
-			got, err := svc.Update(context.Background(), tt.args.subscriptionId, tt.args.ds, tt.args.opts)
+			got, err := svc.Update(context.Background(), projectID, tt.args.subscriptionId, tt.args.ds, tt.args.opts)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -1543,6 +1544,177 @@ func TestUpdate(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.want.Name, got.Name)
+		})
+	}
+}
+
+func TestUpsert(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		subscriptionID uuid.UUID
+		ds             *minderv1.DataSource
+		opts           *Options
+	}
+	tests := []struct {
+		name    string
+		args    args
+		setup   func(mockDB *mockdb.MockStore)
+		wantErr bool
+	}{
+		{
+			name: "Successfully create data source",
+			args: args{
+				subscriptionID: subscriptionID,
+				ds: &minderv1.DataSource{
+					Name: "namespace/test_ds",
+					Context: &minderv1.ContextV2{
+						ProjectId: uuid.New().String(),
+					},
+					Driver: validRESTDriverFixture,
+				},
+				opts: &Options{},
+			},
+			setup: func(mockDB *mockdb.MockStore) {
+				mockDB.EXPECT().GetParentProjects(gomock.Any(), gomock.Any()).
+					Return([]uuid.UUID{uuid.New()}, nil)
+
+				mockDB.EXPECT().GetDataSourceByName(gomock.Any(), gomock.Any()).
+					Return(db.DataSource{}, sql.ErrNoRows)
+
+				mockDB.EXPECT().CreateDataSource(gomock.Any(), gomock.Any()).
+					Return(db.DataSource{
+						ID:   uuid.New(),
+						Name: "namespace/test_ds",
+					}, nil)
+
+				mockDB.EXPECT().AddDataSourceFunction(gomock.Any(), gomock.Any()).
+					Return(db.DataSourcesFunction{}, nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "Successfully update existing data source",
+			args: args{
+				subscriptionID: subscriptionID,
+				ds: &minderv1.DataSource{
+					Name: "namespace/test_ds",
+					Context: &minderv1.ContextV2{
+						ProjectId: uuid.New().String(),
+					},
+					Driver: validRESTDriverFixture,
+				},
+				opts: &Options{},
+			},
+			setup: func(mockDB *mockdb.MockStore) {
+				dsID := uuid.New()
+				mockDB.EXPECT().GetParentProjects(gomock.Any(), gomock.Any()).
+					Return([]uuid.UUID{uuid.New()}, nil)
+
+				// The data source already exists
+				mockDB.EXPECT().GetDataSourceByName(gomock.Any(), gomock.Any()).
+					Return(db.DataSource{
+						ID:             dsID,
+						Name:           "namespace/test_ds",
+						SubscriptionID: uuid.NullUUID{Valid: true, UUID: subscriptionID},
+					}, nil).AnyTimes()
+
+				mockDB.EXPECT().ListDataSourceFunctions(gomock.Any(), gomock.Any()).
+					Return([]db.DataSourcesFunction{
+						{
+							ID:           uuid.New(),
+							DataSourceID: dsID,
+							Name:         "test_function",
+							Type:         v1.DataSourceDriverRest,
+							Definition: restDriverToJson(t, &minderv1.RestDataSource_Def{
+								Endpoint: "http://example.com/updated",
+								InputSchema: func() *structpb.Struct {
+									s, _ := structpb.NewStruct(map[string]any{})
+									return s
+								}(),
+							}),
+						},
+					}, nil)
+
+				mockDB.EXPECT().UpdateDataSource(gomock.Any(), gomock.Any()).
+					Return(db.DataSource{
+						ID:   uuid.New(),
+						Name: "test_ds",
+					}, nil)
+
+				mockDB.EXPECT().DeleteDataSourceFunctions(gomock.Any(), gomock.Any()).
+					Return(nil, nil)
+
+				mockDB.EXPECT().AddDataSourceFunction(gomock.Any(), gomock.Any()).
+					Return(db.DataSourcesFunction{}, nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid namespace name",
+			args: args{
+				ds: &minderv1.DataSource{
+					Name: "name-with-no-namespace",
+					Context: &minderv1.ContextV2{
+						ProjectId: uuid.New().String(),
+					},
+					Driver: validRESTDriverFixture,
+				},
+				subscriptionID: subscriptionID,
+				opts:           &Options{},
+			},
+			setup:   func(_ *mockdb.MockStore) {},
+			wantErr: true,
+		},
+		{
+			name: "Nil data source",
+			args: args{
+				ds:   nil,
+				opts: &Options{},
+			},
+			setup:   func(_ *mockdb.MockStore) {},
+			wantErr: true,
+		},
+		{
+			name: "Invalid project ID",
+			args: args{
+				ds: &minderv1.DataSource{
+					Context: &minderv1.ContextV2{
+						ProjectId: "invalid-uuid",
+					},
+				},
+				opts: &Options{},
+			},
+			setup:   func(_ *mockdb.MockStore) {},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockStore := mockdb.NewMockStore(ctrl)
+
+			svc := NewDataSourceService(mockStore)
+			svc.txBuilder = func(_ *dataSourceService, _ txGetter) (serviceTX, error) {
+				return &fakeTxBuilder{
+					store: mockStore,
+				}, nil
+			}
+			tt.setup(mockStore)
+
+			err := svc.Upsert(context.Background(), projectID, tt.args.subscriptionID, tt.args.ds, tt.args.opts)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
 		})
 	}
 }

--- a/internal/marketplaces/bundles/mock/fixtures/reader.go
+++ b/internal/marketplaces/bundles/mock/fixtures/reader.go
@@ -76,3 +76,19 @@ func WithFailedForEachRuleType(mock BundleMock) {
 		ForEachRuleType(gomock.Any()).
 		Return(errDefault)
 }
+
+func WithSuccessfulForEachDataSource(mock BundleMock) {
+	type argType = func(source *v1.DataSource) error
+	var argument argType
+	mock.EXPECT().
+		ForEachDataSource(gomock.AssignableToTypeOf(argument)).
+		DoAndReturn(func(fn argType) error {
+			return fn(&v1.DataSource{})
+		})
+}
+
+func WithFailedForEachDataSource(mock BundleMock) {
+	mock.EXPECT().
+		ForEachDataSource(gomock.Any()).
+		Return(errDefault)
+}

--- a/internal/marketplaces/bundles/mock/reader.go
+++ b/internal/marketplaces/bundles/mock/reader.go
@@ -41,6 +41,20 @@ func (m *MockBundleReader) EXPECT() *MockBundleReaderMockRecorder {
 	return m.recorder
 }
 
+// ForEachDataSource mocks base method.
+func (m *MockBundleReader) ForEachDataSource(arg0 func(*v1.DataSource) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ForEachDataSource", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ForEachDataSource indicates an expected call of ForEachDataSource.
+func (mr *MockBundleReaderMockRecorder) ForEachDataSource(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForEachDataSource", reflect.TypeOf((*MockBundleReader)(nil).ForEachDataSource), arg0)
+}
+
 // ForEachRuleType mocks base method.
 func (m *MockBundleReader) ForEachRuleType(arg0 func(*v1.RuleType) error) error {
 	m.ctrl.T.Helper()

--- a/internal/marketplaces/factory.go
+++ b/internal/marketplaces/factory.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	datasourceservice "github.com/mindersec/minder/internal/datasources/service"
 	sub "github.com/mindersec/minder/internal/marketplaces/subscriptions"
 	"github.com/mindersec/minder/pkg/config/server"
 	"github.com/mindersec/minder/pkg/mindpak"
@@ -25,6 +26,7 @@ func NewMarketplaceFromServiceConfig(
 	config server.MarketplaceConfig,
 	profile profiles.ProfileService,
 	ruleType ruletypes.RuleTypeService,
+	dataSource datasourceservice.DataSourcesService,
 ) (Marketplace, error) {
 	if !config.Enabled {
 		return NewNoopMarketplace(), nil
@@ -54,7 +56,7 @@ func NewMarketplaceFromServiceConfig(
 		newSources[i] = source
 	}
 
-	subscription := sub.NewSubscriptionService(profile, ruleType)
+	subscription := sub.NewSubscriptionService(profile, ruleType, dataSource)
 	marketplace, err := NewMarketplace(newSources, subscription)
 	if err != nil {
 		return nil, fmt.Errorf("error while creating marketplace: %w", err)

--- a/internal/marketplaces/service.go
+++ b/internal/marketplaces/service.go
@@ -28,7 +28,7 @@ type Marketplace interface {
 		ctx context.Context,
 		projectID uuid.UUID,
 		bundleID mindpak.BundleID,
-		qtx db.Querier,
+		qtx db.ExtendQuerier,
 	) error
 	// AddProfile adds the specified profile from the bundle to the project.
 	AddProfile(
@@ -53,7 +53,7 @@ func (s *marketplace) Subscribe(
 	ctx context.Context,
 	projectID uuid.UUID,
 	bundleID mindpak.BundleID,
-	qtx db.Querier,
+	qtx db.ExtendQuerier,
 ) error {
 	bundle, err := s.getBundle(bundleID)
 	if err != nil {
@@ -100,7 +100,7 @@ func (s *marketplace) getBundle(bundleID mindpak.BundleID) (reader.BundleReader,
 // This is used when the Marketplace functionality is disabled
 type noopMarketplace struct{}
 
-func (_ *noopMarketplace) Subscribe(_ context.Context, _ uuid.UUID, _ mindpak.BundleID, _ db.Querier) error {
+func (_ *noopMarketplace) Subscribe(_ context.Context, _ uuid.UUID, _ mindpak.BundleID, _ db.ExtendQuerier) error {
 	return nil
 }
 

--- a/internal/marketplaces/subscriptions/mock/service.go
+++ b/internal/marketplaces/subscriptions/mock/service.go
@@ -58,7 +58,7 @@ func (mr *MockSubscriptionServiceMockRecorder) CreateProfile(ctx, projectID, bun
 }
 
 // Subscribe mocks base method.
-func (m *MockSubscriptionService) Subscribe(ctx context.Context, projectID uuid.UUID, bundle reader.BundleReader, qtx db.Querier) error {
+func (m *MockSubscriptionService) Subscribe(ctx context.Context, projectID uuid.UUID, bundle reader.BundleReader, qtx db.ExtendQuerier) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Subscribe", ctx, projectID, bundle, qtx)
 	ret0, _ := ret[0].(error)

--- a/internal/projects/creator.go
+++ b/internal/projects/creator.go
@@ -29,7 +29,7 @@ type ProjectCreator interface {
 	// (project, marketplace subscriptions, etc.) but *does not* create a project.
 	ProvisionSelfEnrolledProject(
 		ctx context.Context,
-		qtx db.Querier,
+		qtx db.ExtendQuerier,
 		projectName string,
 		userSub string,
 	) (outproj *db.Project, projerr error)
@@ -63,7 +63,7 @@ var (
 
 func (p *projectCreator) ProvisionSelfEnrolledProject(
 	ctx context.Context,
-	qtx db.Querier,
+	qtx db.ExtendQuerier,
 	projectName string,
 	userSub string,
 ) (outproj *db.Project, projerr error) {

--- a/internal/providers/github/service/mock/service.go
+++ b/internal/providers/github/service/mock/service.go
@@ -60,7 +60,7 @@ func (mr *MockGitHubProviderServiceMockRecorder) CreateGitHubAppProvider(ctx, to
 }
 
 // CreateGitHubAppWithoutInvitation mocks base method.
-func (m *MockGitHubProviderService) CreateGitHubAppWithoutInvitation(ctx context.Context, qtx db.Querier, userID, installationID int64) (*db.Project, error) {
+func (m *MockGitHubProviderService) CreateGitHubAppWithoutInvitation(ctx context.Context, qtx db.ExtendQuerier, userID, installationID int64) (*db.Project, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateGitHubAppWithoutInvitation", ctx, qtx, userID, installationID)
 	ret0, _ := ret[0].(*db.Project)

--- a/internal/providers/github/service/service.go
+++ b/internal/providers/github/service/service.go
@@ -41,7 +41,7 @@ type GitHubProviderService interface {
 	// the installation in preparation for creating a new project when the authorizing user logs in.
 	//
 	// Note that this function may return nil, nil if the installation user is not known to Minder.
-	CreateGitHubAppWithoutInvitation(ctx context.Context, qtx db.Querier, userID int64,
+	CreateGitHubAppWithoutInvitation(ctx context.Context, qtx db.ExtendQuerier, userID int64,
 		installationID int64) (*db.Project, error)
 	// ValidateGitHubInstallationId checks if the supplied GitHub token has access to the installation ID
 	ValidateGitHubInstallationId(ctx context.Context, token *oauth2.Token, installationID int64) error
@@ -67,7 +67,7 @@ var ErrInvalidTokenIdentity = errors.New("invalid token identity")
 // present in the system.  If a db.Project is returned, it should be used as the
 // location to create a Provider corresponding to the GitHub App installation.
 type ProjectFactory func(
-	ctx context.Context, qtx db.Querier, name string, user int64) (*db.Project, error)
+	ctx context.Context, qtx db.ExtendQuerier, name string, user int64) (*db.Project, error)
 
 type ghProviderService struct {
 	store           db.Store
@@ -167,7 +167,7 @@ func (p *ghProviderService) CreateGitHubAppProvider(
 // Note that this function may return nil, nil if the installation user is not known to Minder.
 func (p *ghProviderService) CreateGitHubAppWithoutInvitation(
 	ctx context.Context,
-	qtx db.Querier,
+	qtx db.ExtendQuerier,
 	userID int64,
 	installationID int64,
 ) (*db.Project, error) {

--- a/internal/providers/github/service/service_test.go
+++ b/internal/providers/github/service/service_test.go
@@ -308,7 +308,7 @@ func TestProviderService_CreateGitHubAppWithNewProject(t *testing.T) {
 			PrivateKey: pvtKeyFile.Name(),
 		},
 	}
-	factory := func(_ context.Context, qtx db.Querier, name string, _ int64) (*db.Project, error) {
+	factory := func(_ context.Context, qtx db.ExtendQuerier, name string, _ int64) (*db.Project, error) {
 		project, err := qtx.CreateProject(context.Background(), db.CreateProjectParams{
 			Name:     name,
 			Metadata: []byte(`{}`),
@@ -374,7 +374,7 @@ func TestProviderService_CreateUnclaimedGitHubAppInstallation(t *testing.T) {
 		},
 	}
 
-	factory := func(context.Context, db.Querier, string, int64) (*db.Project, error) {
+	factory := func(context.Context, db.ExtendQuerier, string, int64) (*db.Project, error) {
 		return nil, errors.New("error getting user for GitHub ID: 404 not found")
 	}
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -95,7 +95,8 @@ func AllInOneServerService(
 	profileSvc := profiles.NewProfileService(evt, selChecker)
 	ruleSvc := ruletypes.NewRuleTypeService()
 	roleScv := roles.NewRoleService()
-	marketplace, err := marketplaces.NewMarketplaceFromServiceConfig(cfg.Marketplace, profileSvc, ruleSvc)
+	dataSourcesSvc := datasourcessvc.NewDataSourceService(store)
+	marketplace, err := marketplaces.NewMarketplaceFromServiceConfig(cfg.Marketplace, profileSvc, ruleSvc, dataSourcesSvc)
 	if err != nil {
 		return fmt.Errorf("failed to create marketplace: %w", err)
 	}
@@ -171,7 +172,6 @@ func AllInOneServerService(
 	repos := repositories.NewRepositoryService(store, propSvc, evt, providerManager)
 	projectDeleter := projects.NewProjectDeleter(authzClient, providerManager)
 	sessionsService := session.NewProviderSessionService(providerManager, providerStore, store)
-	dataSourcesSvc := datasourcessvc.NewDataSourceService(store)
 
 	s := controlplane.NewServer(
 		store,
@@ -332,7 +332,7 @@ func makeProjectFactory(
 ) service.ProjectFactory {
 	return func(
 		ctx context.Context,
-		qtx db.Querier,
+		qtx db.ExtendQuerier,
 		name string,
 		ghUser int64,
 	) (*db.Project, error) {

--- a/pkg/mindpak/bundle_test.go
+++ b/pkg/mindpak/bundle_test.go
@@ -43,6 +43,7 @@ func TestReadSource(t *testing.T) {
 							Hashes: map[HashAlgorithm]string{SHA256: "3857bca2ccabdac3d136eb3df4549ddd87a00ddef9fdcf88d8f824e5e796d34c"},
 						},
 					},
+					DataSources: []*File{},
 				},
 				Source: nil,
 			},

--- a/pkg/mindpak/mindpack.go
+++ b/pkg/mindpak/mindpack.go
@@ -17,6 +17,9 @@ const (
 	// PathRuleTypes is the name of the directory holding the rule types of a bundle
 	PathRuleTypes = "rule_types"
 
+	// PathDataSources is the name of the directory holding the data sources of a bundle
+	PathDataSources = "data_sources"
+
 	// ManifestFileName is the defaul filename for the manifest
 	ManifestFileName = "manifest.json"
 )
@@ -42,6 +45,7 @@ type File struct {
 
 // Files is a collection of the files included in the bundle organized by type
 type Files struct {
-	Profiles  []*File `json:"profiles,omitempty"`
-	RuleTypes []*File `json:"ruleTypes,omitempty"`
+	Profiles    []*File `json:"profiles,omitempty"`
+	RuleTypes   []*File `json:"ruleTypes,omitempty"`
+	DataSources []*File `json:"dataSources,omitempty"`
 }

--- a/pkg/mindpak/testdata/no-data-sources/profiles/branch-protection-github-profile.yaml
+++ b/pkg/mindpak/testdata/no-data-sources/profiles/branch-protection-github-profile.yaml
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright 2025 The Minder Authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# A profile to verify branch protection settings
+version: v1
+type: profile
+name: branch-protection-github-profile
+context:
+  provider: github
+alert: "off"
+remediate: "off"
+repository:
+  - type: branch_protection_enabled
+    params:
+      branch: ""
+    def: {}
+  - type: branch_protection_allow_deletions
+    params:
+      branch: ""
+    def:
+      allow_deletions: false
+  - type: branch_protection_allow_force_pushes
+    params:
+      branch: ""
+    def:
+      allow_force_pushes: false
+  - type: branch_protection_enforce_admins
+    params:
+      branch: ""
+    def:
+      enforce_admins: true
+  - type: branch_protection_lock_branch
+    params:
+      branch: ""
+    def:
+      lock_branch: false
+  - type: branch_protection_require_conversation_resolution
+    params:
+      branch: ""
+    def:
+      required_conversation_resolution: false
+  - type: branch_protection_require_pull_request_approving_review_count
+    params:
+      branch: ""
+    def:
+      required_approving_review_count: 1
+  - type: branch_protection_require_pull_request_code_owners_review
+    params:
+      branch: ""
+    def:
+      require_code_owner_reviews: false
+  - type: branch_protection_require_pull_request_dismiss_stale_reviews
+    params:
+      branch: ""
+    def:
+      dismiss_stale_reviews: true
+  - type: branch_protection_require_pull_request_last_push_approval
+    params:
+      branch: ""
+    def:
+      require_last_push_approval: true
+  - type: branch_protection_require_pull_requests
+    params:
+      branch: ""
+    def:
+      required_pull_request_reviews: true
+  - type: branch_protection_require_signatures
+    params:
+      branch: ""
+    def:
+      required_signatures: false

--- a/pkg/mindpak/testdata/no-data-sources/rule_types/branch_protection_enabled.yaml
+++ b/pkg/mindpak/testdata/no-data-sources/rule_types/branch_protection_enabled.yaml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright 2025 The Minder Authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+version: v1
+type: rule-type
+name: branch_protection_enabled
+context:
+  provider: github
+description: Verifies that a branch has a branch protection rule
+guidance: |
+  You can protect important branches by setting branch protection rules, which define whether
+  collaborators can delete or force push to the branch and set requirements for any pushes to the branch,
+  such as passing status checks or a linear commit history.
+
+  For more information, see
+  https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
+def:
+  # Defines the section of the pipeline the rule will appear in.
+  # This will affect the template used to render multiple parts
+  # of the rule.
+  in_entity: repository
+  # Defines the schema for parameters that will be passed to the rule
+  param_schema:
+    properties:
+      branch:
+        type: string
+        description: "The name of the branch to check. If left empty, the default branch will be used."
+    required:
+      - branch
+  rule_schema: {}
+  # Defines the configuration for ingesting data relevant for the rule
+  ingest:
+    type: rest
+    rest:
+      # This is the path to the data source. Given that this will evaluate
+      # for each repository in the organization, we use a template that
+      # will be evaluated for each repository. The structure to use is the
+      # protobuf structure for the entity that is being evaluated.
+      endpoint: '{{ $branch_param := index .Params "branch" }}/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{if ne $branch_param "" }}{{ $branch_param }}{{ else }}{{ .Entity.DefaultBranch }}{{ end }}/protection'
+      # This is the method to use to retrieve the data. It should already default to JSON
+      parse: json
+      fallback:
+        - http_code: 404
+          body: |
+            {"http_status": 404, "message": "Not Protected"}
+  eval:
+    type: rego
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+        
+        import future.keywords.every
+        import future.keywords.if
+        
+        default allow := false
+        
+        allow if {
+          input.ingested.url != ""
+        }
+  # Defines the configuration for alerting on the rule
+  alert:
+    type: security_advisory
+    security_advisory:
+      severity: "medium"

--- a/pkg/mindpak/testdata/t2/data_sources/osv.yaml
+++ b/pkg/mindpak/testdata/t2/data_sources/osv.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright 2024 The Minder Authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+version: v1
+type: data-source
+name: osv
+context: {}
+rest:
+  def:
+    query:
+      endpoint: 'https://api.osv.dev/v1/query'
+      parse: json
+      method: POST
+      body_from_field: query
+      input_schema:
+        type: object
+        properties:
+          query:
+            type: object
+            properties:
+              version:
+                type: string
+              package:
+                type: object
+                properties:
+                  ecosystem:
+                    type: string
+                    description: The ecosystem the dependency belongs to
+                  name:
+                    type: string
+                    description: The name of the dependency
+        required:
+          - query


### PR DESCRIPTION
# Summary

This allows Minder to create data sources from a bundle when a new user registers.

A part of this PR involves changing the parameter type in several functions from a `db.Querier` to a `db.ExtendQuerier`, making it more specific.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
