### PR TITLE
Datasource cleanup: introduce some types and avoid pass-by-context

### DIFF
--- a/internal/datasources/rest/handler_test.go
+++ b/internal/datasources/rest/handler_test.go
@@ -252,7 +252,7 @@ func Test_restHandler_Call(t *testing.T) {
 				headers:      tt.fields.headers,
 				parse:        tt.fields.parse,
 			}
-			got, err := h.Call(context.Background(), tt.args.args)
+			got, err := h.Call(context.Background(), nil, tt.args.args)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -367,7 +367,7 @@ func Test_restHandler_ValidateUpdate(t *testing.T) {
 	t.Parallel()
 
 	type args struct {
-		updateSchema any
+		updateSchema *structpb.Struct
 	}
 	tests := []struct {
 		name        string
@@ -407,34 +407,6 @@ func Test_restHandler_ValidateUpdate(t *testing.T) {
 				},
 			},
 			wantErr: false,
-		},
-		{
-			name: "Valid map[string]any",
-			inputSchema: map[string]any{
-				"type":       "object",
-				"properties": map[string]any{"key": map[string]any{"type": "string"}},
-			},
-			args: args{
-				updateSchema: map[string]any{
-					"type": "object",
-					"properties": map[string]any{
-						"key":     map[string]any{"type": "string"},
-						"new_key": map[string]any{"type": "number"},
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "Invalid type",
-			inputSchema: map[string]any{
-				"type":       "object",
-				"properties": map[string]any{"key": map[string]any{"type": "string"}},
-			},
-			args: args{
-				updateSchema: "invalid_type",
-			},
-			wantErr: true,
 		},
 		{
 			name: "nil update schema",

--- a/internal/datasources/structured/handler.go
+++ b/internal/datasources/structured/handler.go
@@ -150,7 +150,7 @@ func parseFile(f billy.File) (any, error) {
 }
 
 // Call parses the structured data from the billy filesystem in the context
-func (sh *structHandler) Call(ctx context.Context, ingest *interfaces.Result, _ any) (any, error) {
+func (sh *structHandler) Call(_ context.Context, ingest *interfaces.Result, _ any) (any, error) {
 	if ingest == nil || ingest.Fs == nil {
 		return nil, fmt.Errorf("filesystem not found in execution context")
 	}

--- a/internal/datasources/structured/handler.go
+++ b/internal/datasources/structured/handler.go
@@ -15,9 +15,11 @@ import (
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/rs/zerolog/log"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
 	v1datasources "github.com/mindersec/minder/pkg/datasources/v1"
+	"github.com/mindersec/minder/pkg/engine/v1/interfaces"
 )
 
 const (
@@ -148,21 +150,15 @@ func parseFile(f billy.File) (any, error) {
 }
 
 // Call parses the structured data from the billy filesystem in the context
-func (sh *structHandler) Call(ctx context.Context, _ any) (any, error) {
-	var ctxData v1datasources.Context
-	var ok bool
-	if ctxData, ok = ctx.Value(v1datasources.ContextKey{}).(v1datasources.Context); !ok {
-		return nil, fmt.Errorf("unable to read execution context")
-	}
-
-	if ctxData.Ingest == nil || ctxData.Ingest.Fs == nil {
+func (sh *structHandler) Call(ctx context.Context, ingest *interfaces.Result, _ any) (any, error) {
+	if ingest == nil || ingest.Fs == nil {
 		return nil, fmt.Errorf("filesystem not found in execution context")
 	}
 
-	return parseFileAlternatives(ctxData.Ingest.Fs, sh.Path.GetFileName(), sh.Path.GetAlternatives())
+	return parseFileAlternatives(ingest.Fs, sh.Path.GetFileName(), sh.Path.GetAlternatives())
 }
 
-func (*structHandler) GetArgsSchema() any {
+func (*structHandler) GetArgsSchema() *structpb.Struct {
 	return nil
 }
 
@@ -172,6 +168,6 @@ func (_ *structHandler) ValidateArgs(any) error {
 }
 
 // ValidateUpdate
-func (_ *structHandler) ValidateUpdate(any) error {
+func (_ *structHandler) ValidateUpdate(*structpb.Struct) error {
 	return nil
 }

--- a/internal/engine/eval/rego/datasources.go
+++ b/internal/engine/eval/rego/datasources.go
@@ -4,7 +4,6 @@
 package rego
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -48,7 +47,7 @@ func buildFromDataSource(
 			Name: k,
 			Decl: types.NewFunction(types.Args(types.A), types.A),
 		},
-		func(_ rego.BuiltinContext, obj *ast.Term) (*ast.Term, error) {
+		func(bctx rego.BuiltinContext, obj *ast.Term) (*ast.Term, error) {
 			// Convert the AST value back to a Go interface{}
 			jsonObj, err := ast.JSON(obj.Value)
 			if err != nil {
@@ -59,15 +58,7 @@ func buildFromDataSource(
 				return nil, err
 			}
 
-			// Call the data source function
-			ctx := context.WithValue(
-				context.Background(),
-				v1datasources.ContextKey{},
-				v1datasources.Context{
-					Ingest: res,
-				},
-			)
-			ret, err := dsf.Call(ctx, jsonObj)
+			ret, err := dsf.Call(bctx.Context, res, jsonObj)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/engine/eval/rego/rego_test.go
+++ b/internal/engine/eval/rego/rego_test.go
@@ -522,7 +522,7 @@ allow {
 	emptyPol := map[string]any{}
 
 	// Matches
-	fdsf.EXPECT().Call(gomock.Any(), gomock.Any()).Return("foo", nil)
+	fdsf.EXPECT().Call(gomock.Any(), gomock.Any(), gomock.Any()).Return("foo", nil)
 	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
 		Object: map[string]any{
 			"data": "foo",
@@ -531,7 +531,7 @@ allow {
 	require.NoError(t, err, "could not evaluate")
 
 	// Doesn't match
-	fdsf.EXPECT().Call(gomock.Any(), gomock.Any()).Return("bar", nil)
+	fdsf.EXPECT().Call(gomock.Any(), gomock.Any(), gomock.Any()).Return("bar", nil)
 	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
 		Object: map[string]any{
 			"data": "bar",

--- a/pkg/datasources/v1/datasources.go
+++ b/pkg/datasources/v1/datasources.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/mindersec/minder/pkg/engine/v1/interfaces"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 //go:generate go run go.uber.org/mock/mockgen -package mock_$GOPACKAGE -destination=./mock/$GOFILE -source=./$GOFILE
@@ -36,14 +37,14 @@ type DataSourceFuncDef interface {
 	// ValidateUpdate validates the update to the data source.
 	// The data source implementation should respect the update and return an error
 	// if the update is invalid.
-	ValidateUpdate(obj any) error
+	ValidateUpdate(obj *structpb.Struct) error
 	// Call calls the function with the given arguments.
 	// It is the responsibility of the data source implementation to handle the call.
 	// It is also the responsibility of the caller to validate the arguments
 	// before calling the function.
-	Call(ctx context.Context, args any) (any, error)
+	Call(ctx context.Context, ingest *interfaces.Result, args any) (any, error)
 	// GetArgsSchema returns the schema of the arguments.
-	GetArgsSchema() any
+	GetArgsSchema() *structpb.Struct
 }
 
 // DataSource is the interface that a data source must implement.

--- a/pkg/datasources/v1/datasources.go
+++ b/pkg/datasources/v1/datasources.go
@@ -7,8 +7,9 @@ package v1
 import (
 	"context"
 
-	"github.com/mindersec/minder/pkg/engine/v1/interfaces"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/mindersec/minder/pkg/engine/v1/interfaces"
 )
 
 //go:generate go run go.uber.org/mock/mockgen -package mock_$GOPACKAGE -destination=./mock/$GOFILE -source=./$GOFILE

--- a/pkg/datasources/v1/mock/datasources.go
+++ b/pkg/datasources/v1/mock/datasources.go
@@ -14,7 +14,9 @@ import (
 	reflect "reflect"
 
 	v1 "github.com/mindersec/minder/pkg/datasources/v1"
+	interfaces "github.com/mindersec/minder/pkg/engine/v1/interfaces"
 	gomock "go.uber.org/mock/gomock"
+	structpb "google.golang.org/protobuf/types/known/structpb"
 )
 
 // MockDataSourceFuncDef is a mock of DataSourceFuncDef interface.
@@ -42,25 +44,25 @@ func (m *MockDataSourceFuncDef) EXPECT() *MockDataSourceFuncDefMockRecorder {
 }
 
 // Call mocks base method.
-func (m *MockDataSourceFuncDef) Call(ctx context.Context, args any) (any, error) {
+func (m *MockDataSourceFuncDef) Call(ctx context.Context, ingest *interfaces.Result, args any) (any, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Call", ctx, args)
+	ret := m.ctrl.Call(m, "Call", ctx, ingest, args)
 	ret0, _ := ret[0].(any)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Call indicates an expected call of Call.
-func (mr *MockDataSourceFuncDefMockRecorder) Call(ctx, args any) *gomock.Call {
+func (mr *MockDataSourceFuncDefMockRecorder) Call(ctx, ingest, args any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Call", reflect.TypeOf((*MockDataSourceFuncDef)(nil).Call), ctx, args)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Call", reflect.TypeOf((*MockDataSourceFuncDef)(nil).Call), ctx, ingest, args)
 }
 
 // GetArgsSchema mocks base method.
-func (m *MockDataSourceFuncDef) GetArgsSchema() any {
+func (m *MockDataSourceFuncDef) GetArgsSchema() *structpb.Struct {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetArgsSchema")
-	ret0, _ := ret[0].(any)
+	ret0, _ := ret[0].(*structpb.Struct)
 	return ret0
 }
 
@@ -85,7 +87,7 @@ func (mr *MockDataSourceFuncDefMockRecorder) ValidateArgs(obj any) *gomock.Call 
 }
 
 // ValidateUpdate mocks base method.
-func (m *MockDataSourceFuncDef) ValidateUpdate(obj any) error {
+func (m *MockDataSourceFuncDef) ValidateUpdate(obj *structpb.Struct) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateUpdate", obj)
 	ret0, _ := ret[0].(error)


### PR DESCRIPTION
# Summary

While working on #5094, I discovered that there was some over-use of `any` and reflection that (IMO) made the code harder to understand.  This hopefully contributes to polishing datasources for release.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Tested with `go test`, which was helpful for finding all the places where signatures changed.  Otherwise, this should be a no-op.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
