### PR TITLE
Update generated proto reference doc to .mdx

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,7 @@
 /database/mock/*.go linguist-generated=true
 /docs/docs/ref/cli/*.md linguist-generated=true
 /docs/docs/ref/schema.md linguist-generated=true
-/docs/docs/ref/proto.md linguist-generated=true
+/docs/docs/ref/proto.mdx linguist-generated=true
 /pkg/api/openapi/** linguist-generated=true
 /pkg/api/protobuf/go/minder/v1/*.pb.go linguist-generated=true
 /pkg/api/protobuf/go/minder/v1/*.gw.go linguist-generated=true

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -26,4 +26,4 @@ plugins:
     # https://github.com/pseudomuto/protoc-gen-doc/issues/513
     # buf.build/community/pseudomuto-doc:v1.5.1
     out: docs/docs/ref
-    opt: "docs/proto_template.tmpl,proto.md:internal.proto"
+    opt: "docs/proto_template.tmpl,proto.mdx:internal.proto"

--- a/docs/.markdownlint-cli2.jsonc
+++ b/docs/.markdownlint-cli2.jsonc
@@ -1,11 +1,5 @@
 {
   "gitignore": true,
   "globs": ["**/*.md"],
-  "ignores": [
-    "node_modules/",
-    ".docusaurus",
-    "build/",
-    "docs/ref/cli/",
-    "docs/ref/proto.md",
-  ],
+  "ignores": ["node_modules/", ".docusaurus", "build/", "docs/ref/cli/"],
 }

--- a/docs/.prettierignore
+++ b/docs/.prettierignore
@@ -4,4 +4,4 @@ build/
 
 # Auto-generated files
 docs/ref/cli/*.md
-docs/ref/proto.md
+docs/ref/proto.mdx

--- a/docs/docs/ref/proto.mdx
+++ b/docs/docs/ref/proto.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 60
 title: Protocol documentation
+sidebar_position: 60
 toc_max_heading_level: 4
 ---
 

--- a/docs/eslint.config.mjs
+++ b/docs/eslint.config.mjs
@@ -11,13 +11,7 @@ import * as mdx from 'eslint-plugin-mdx';
 /** @type {import('eslint').Linter.Config[]} */
 export default [
   {
-    ignores: [
-      '.docusaurus/',
-      'build/',
-      'import/',
-      'docs/minder/',
-      'node_modules/',
-    ],
+    ignores: ['.docusaurus/', 'build/', 'node_modules/', 'docs/ref/proto.mdx'],
   },
   { files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'] },
   { languageOptions: { globals: globals.node } },

--- a/docs/proto_template.tmpl
+++ b/docs/proto_template.tmpl
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 60
 title: Protocol documentation
+sidebar_position: 60
 toc_max_heading_level: 4
 ---
 


### PR DESCRIPTION
# Summary

Renames the `proto.md` generated reference doc to `proto.mdx`.

Future proofing: The file has inline JSX. Docusaurus currently renders all .md and .mdx with the MDX compiler so this works, but the next major version will change this (.md will be compiled with CommonMark instead; [reference](https://docusaurus.io/docs/migration/v3#using-the-mdx-extension)).

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [x] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Ran `make gen` to confirm the .mdx file is generated as expected and the docs site builds.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [x] (N/A) Included tests that validate the fix or feature.
- [x] (N/A) Checked that related changes are merged.
