### PR TITLE
Fall back to generic env for selectors

### DIFF
--- a/internal/controlplane/handlers_profile_test.go
+++ b/internal/controlplane/handlers_profile_test.go
@@ -241,30 +241,6 @@ func TestCreateProfile(t *testing.T) {
 			wantErr: `unsupported entity type: invalid entity type no_such_entity: unsupported entity type`,
 		},
 		{
-			name: "Selector with valid but unsupported entity",
-			profile: &minderv1.CreateProfileRequest{
-				Profile: &minderv1.Profile{
-					Name:      "test_selectors_bad_entity",
-					Alert:     proto.String("off"),
-					Remediate: proto.String("off"),
-					Repository: []*minderv1.Profile_Rule{{
-						Type: "rule_type_1",
-						Def:  &structpb.Struct{},
-					}},
-					Selection: []*minderv1.Profile_Selector{
-						{
-							// this entity is valid in the sense that it converts to an entity type but
-							// the current selelectors implementation does not support it
-							Entity:      "build_environment",
-							Selector:    "repository.name != 'stacklok/demo-repo-go'",
-							Description: "Exclude stacklok/demo-repo-go",
-						},
-					},
-				},
-			},
-			wantErr: `unsupported entity type: no environment for entity ENTITY_BUILD_ENVIRONMENTS: unsupported entity type`,
-		},
-		{
 			name: "Selector does not parse",
 			profile: &minderv1.CreateProfileRequest{
 				Profile: &minderv1.Profile{

--- a/pkg/engine/selectors/selectors.go
+++ b/pkg/engine/selectors/selectors.go
@@ -355,11 +355,23 @@ func (e *Env) CheckSelector(sel *minderv1.Profile_Selector) error {
 func (e *Env) envForEntity(entity minderv1.Entity) (*cel.Env, error) {
 	cache, ok := e.entityEnvs[entity]
 	if !ok {
-		return nil, fmt.Errorf("no cache found for entity %v", entity)
+		// if the entity isn't in the env map, we use the generic environment
+		cache, ok = e.entityEnvs[minderv1.Entity_ENTITY_UNSPECIFIED]
+		if !ok {
+			return nil, fmt.Errorf("no cache found for entity %v", entity)
+		}
 	}
 
+	factory, ok := e.factories[entity]
+	if !ok {
+		// if the entity isn't in the factory map, we use the generic environment
+		factory, ok = e.factories[minderv1.Entity_ENTITY_UNSPECIFIED]
+		if !ok {
+			return nil, fmt.Errorf("no factory found for entity %v", entity)
+		}
+	}
 	cache.once.Do(func() {
-		cache.env, cache.err = e.factories[entity]()
+		cache.env, cache.err = factory()
 	})
 
 	return cache.env, cache.err


### PR DESCRIPTION
# Summary

When an entity type does not have a specific CEL environment, fall back to the generic environment.

Fix #5375

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
