### PR TITLE
Adds check to ensure config file exists. Fixes: #4513

### DIFF
--- a/cmd/cli/app/auth/auth_login.go
+++ b/cmd/cli/app/auth/auth_login.go
@@ -5,8 +5,6 @@ package auth
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -29,23 +27,13 @@ $XDG_CONFIG_HOME/minder/credentials.json`,
 
 // LoginCommand is the login subcommand
 func LoginCommand(ctx context.Context, cmd *cobra.Command, _ []string, _ *grpc.ClientConn) error {
-	v := viper.GetViper()
-
-	// No longer print usage on returned error, since we've parsed our inputs
-	// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
-	cmd.SilenceUsage = true
-
-	// If config file is specified but doesn't exist, that's an error
-	if configFile := v.GetString("config"); configFile != "" {
-		if _, err := os.Stat(configFile); os.IsNotExist(err) {
-			return cli.MessageAndError("Config file does not exist", fmt.Errorf("file %s not found", configFile))
-		}
-	}
-
-	clientConfig, err := config.ReadConfigFromViper[clientconfig.Config](v)
+	clientConfig, err := config.ReadConfigFromViper[clientconfig.Config](viper.GetViper())
 	if err != nil {
 		return cli.MessageAndError("Unable to read config", err)
 	}
+	// No longer print usage on returned error, since we've parsed our inputs
+	// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
+	cmd.SilenceUsage = true
 
 	filePath, err := cli.LoginAndSaveCreds(ctx, cmd, clientConfig)
 	if err != nil {

--- a/cmd/cli/app/auth/auth_login.go
+++ b/cmd/cli/app/auth/auth_login.go
@@ -5,8 +5,6 @@ package auth
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -29,23 +27,15 @@ $XDG_CONFIG_HOME/minder/credentials.json`,
 
 // LoginCommand is the login subcommand
 func LoginCommand(ctx context.Context, cmd *cobra.Command, _ []string, _ *grpc.ClientConn) error {
-	v := viper.GetViper()
+
+	clientConfig, err := config.ReadConfigFromViper[clientconfig.Config](viper.GetViper())
+	if err != nil {
+		return cli.MessageAndError("Unable to read config", err)
+	}
 
 	// No longer print usage on returned error, since we've parsed our inputs
 	// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
 	cmd.SilenceUsage = true
-
-	// If config file is specified but doesn't exist, that's an error
-	if configFile := v.GetString("config"); configFile != "" {
-		if _, err := os.Stat(configFile); os.IsNotExist(err) {
-			return cli.MessageAndError("Config file does not exist", fmt.Errorf("file %s not found", configFile))
-		}
-	}
-
-	clientConfig, err := config.ReadConfigFromViper[clientconfig.Config](v)
-	if err != nil {
-		return cli.MessageAndError("Unable to read config", err)
-	}
 
 	filePath, err := cli.LoginAndSaveCreds(ctx, cmd, clientConfig)
 	if err != nil {

--- a/cmd/cli/app/auth/auth_login.go
+++ b/cmd/cli/app/auth/auth_login.go
@@ -5,6 +5,8 @@ package auth
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -27,13 +29,23 @@ $XDG_CONFIG_HOME/minder/credentials.json`,
 
 // LoginCommand is the login subcommand
 func LoginCommand(ctx context.Context, cmd *cobra.Command, _ []string, _ *grpc.ClientConn) error {
-	clientConfig, err := config.ReadConfigFromViper[clientconfig.Config](viper.GetViper())
-	if err != nil {
-		return cli.MessageAndError("Unable to read config", err)
-	}
+	v := viper.GetViper()
+
 	// No longer print usage on returned error, since we've parsed our inputs
 	// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
 	cmd.SilenceUsage = true
+
+	// If config file is specified but doesn't exist, that's an error
+	if configFile := v.GetString("config"); configFile != "" {
+		if _, err := os.Stat(configFile); os.IsNotExist(err) {
+			return cli.MessageAndError("Config file does not exist", fmt.Errorf("file %s not found", configFile))
+		}
+	}
+
+	clientConfig, err := config.ReadConfigFromViper[clientconfig.Config](v)
+	if err != nil {
+		return cli.MessageAndError("Unable to read config", err)
+	}
 
 	filePath, err := cli.LoginAndSaveCreds(ctx, cmd, clientConfig)
 	if err != nil {

--- a/cmd/cli/app/auth/auth_login.go
+++ b/cmd/cli/app/auth/auth_login.go
@@ -5,6 +5,8 @@ package auth
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -27,15 +29,23 @@ $XDG_CONFIG_HOME/minder/credentials.json`,
 
 // LoginCommand is the login subcommand
 func LoginCommand(ctx context.Context, cmd *cobra.Command, _ []string, _ *grpc.ClientConn) error {
-
-	clientConfig, err := config.ReadConfigFromViper[clientconfig.Config](viper.GetViper())
-	if err != nil {
-		return cli.MessageAndError("Unable to read config", err)
-	}
+	v := viper.GetViper()
 
 	// No longer print usage on returned error, since we've parsed our inputs
 	// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
 	cmd.SilenceUsage = true
+
+	// If config file is specified but doesn't exist, that's an error
+	if configFile := v.GetString("config"); configFile != "" {
+		if _, err := os.Stat(configFile); os.IsNotExist(err) {
+			return cli.MessageAndError("Config file does not exist", fmt.Errorf("file %s not found", configFile))
+		}
+	}
+
+	clientConfig, err := config.ReadConfigFromViper[clientconfig.Config](v)
+	if err != nil {
+		return cli.MessageAndError("Unable to read config", err)
+	}
 
 	filePath, err := cli.LoginAndSaveCreds(ctx, cmd, clientConfig)
 	if err != nil {

--- a/cmd/cli/app/root.go
+++ b/cmd/cli/app/root.go
@@ -104,11 +104,48 @@ func initConfig() {
 	viper.SetEnvPrefix("minder")
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 
-	cfgFilePath := cli.GetRelevantCLIConfigPath(viper.GetViper())
-	if cfgFilePath != "" {
-		cfgFileData, err := config.GetConfigFileData(cfgFilePath)
+	// Get the config flag value directly to ensure we catch explicitly specified configs
+	configFlag := viper.GetString("config")
+	if configFlag != "" {
+		// User explicitly specified a config file via --config flag
+		if _, err := os.Stat(configFlag); err != nil {
+			RootCmd.PrintErrln(fmt.Sprintf("Cannot find specified config file: %s", configFlag))
+			os.Exit(1)
+		}
+		viper.SetConfigFile(configFlag)
+	} else {
+		// No config file specified, use defaults
+		viper.SetConfigName("config")
+		viper.AddConfigPath(".")
+		if cfgDirPath := cli.GetDefaultCLIConfigPath(); cfgDirPath != "" {
+			viper.AddConfigPath(cfgDirPath)
+		}
+	}
+
+	viper.SetConfigType("yaml")
+	viper.AutomaticEnv()
+
+	if err := viper.ReadInConfig(); err != nil {
+		if configFlag != "" {
+			// If there's any error, we should fail
+			RootCmd.PrintErrln(fmt.Sprintf("Error reading config file %s: %v", configFlag, err))
+			os.Exit(1)
+		}
+
+		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+			// Only allow "config not found" when no config was explicitly specified
+			RootCmd.PrintErrln("No config file present, using default values.")
+		} else {
+			RootCmd.PrintErrln(fmt.Sprintf("Error reading config file: %s", err))
+			os.Exit(1)
+		}
+	}
+
+	// If we successfully read a config file, check for null values
+	if configFlag != "" {
+		cfgFileData, err := config.GetConfigFileData(configFlag)
 		if err != nil {
-			RootCmd.PrintErrln(err)
+			RootCmd.PrintErrln(fmt.Sprintf("Error reading config file data: %v", err))
 			os.Exit(1)
 		}
 
@@ -119,27 +156,6 @@ func initConfig() {
 				RootCmd.PrintErrln("Null Value at: " + key)
 			}
 			os.Exit(1)
-		}
-
-		viper.SetConfigFile(cfgFilePath)
-	} else {
-		// use defaults
-		viper.SetConfigName("config")
-		viper.AddConfigPath(".")
-		if cfgDirPath := cli.GetDefaultCLIConfigPath(); cfgDirPath != "" {
-			viper.AddConfigPath(cfgDirPath)
-		}
-	}
-	viper.SetConfigType("yaml")
-	viper.AutomaticEnv()
-
-	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			// Config file not found; use default values
-			RootCmd.PrintErrln("No config file present, using default values.")
-		} else {
-			// Some other error occurred
-			RootCmd.Printf("Error reading config file: %s", err)
 		}
 	}
 }


### PR DESCRIPTION
# Summary

Added to check to ensure config file actually exists if flag is used. 

Fixes #4513 

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

**No flag (minder auth login) - SAME AS PREVIOUSLY**
Works as intended

**Flag + no file (minder auth login --config) - SAME AS PREVIOUSLY**
Usage 
“Details: flag needs an argument: --config”

**Flag + non-existant file (minder auth login --config blah) - FIXED**
Message: Config file does not exist
Details: file blah not found

**Flag + valid file (minder auth login --config config.yaml) - SAME AS PREVIOUSLY**
Works as intended

**Flag + invalid file(minder auth login --config go.sum) - SAME AS PREVIOUSLY**
Error reading config file: While parsing config: yaml: unmarshal errors:
line 1: cannot unmarshal !!str `buf.bui...` into map[string]interface {}
Still took user to login page

**Flag + invalid file (minder auth login --config LICENSE) - SAME AS PREVIOUSLY**
yaml: line 92: mapping values are not allowed in this context

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
