### PR TITLE
Remove score from trusty evaluator

### DIFF
--- a/internal/engine/eval/trusty/actions.go
+++ b/internal/engine/eval/trusty/actions.go
@@ -53,7 +53,6 @@ Archived packages are no longer updated or maintained. This can lead to security
 {{ if .Deprecated }}
 ⚠️ __Deprecated Package:__ This package is marked as archived. Proceed with caution!
 {{ end }}
-#### Trusty Score: {{ .Score }}
 {{ if .ScoreComponents }}
 <details>
   <summary>Scoring details</summary>
@@ -98,10 +97,10 @@ Archived packages are no longer updated or maintained. This can lead to security
 <details>
   <summary>Alternatives</summary>
 
-  | Package             | Score | Description |
-  | ------------------- | ----: | ----------- |
+  | Package             | Description |
+  | ------------------- | ----------- |
 {{ range .Alternatives -}}
-  | [{{ .PackageName }}]({{ .TrustyURL }})  | {{ .Score }} | {{ .Summary }} |
+  | [{{ .PackageName }}]({{ .TrustyURL }})  | {{ .Summary }} |
 {{ end }}
 </details>
 {{- end -}}

--- a/internal/engine/eval/trusty/trusty.go
+++ b/internal/engine/eval/trusty/trusty.go
@@ -586,10 +586,6 @@ func classifyDependency(
 		packageScore = *resp.Score
 	}
 
-	if ecoConfig.Score > packageScore {
-		reasons = append(reasons, TRUSTY_LOW_SCORE)
-	}
-
 	if ecoConfig.Provenance > resp.ProvenanceScore && resp.ProvenanceScore > 0 {
 		reasons = append(reasons, TRUSTY_LOW_PROVENANCE)
 	}

--- a/internal/engine/eval/trusty/trusty_test.go
+++ b/internal/engine/eval/trusty/trusty_test.go
@@ -241,20 +241,6 @@ func TestClassifyDependency(t *testing.T) {
 			mustFilter: false,
 		},
 		{
-			name: "normal-bad-score",
-			score: &trustyReport{
-				PackageName: "test",
-				PackageType: "npm",
-				Score:       mkfloat(4.0),
-			},
-			config: defaultConfig(),
-			expected: &dependencyAlternatives{
-				Reasons:     []RuleViolationReason{TRUSTY_LOW_SCORE},
-				trustyReply: &trustyReport{},
-			},
-			mustFilter: true,
-		},
-		{
 			name: "normal-malicious",
 			score: &trustyReport{
 				PackageName:  "test",


### PR DESCRIPTION
# Summary
This is a temporary fix, since this code will eventually be removed from Minder and rewritten as a ruletype.

The Trusty ruletype was getting very noisy because every package had a score of 0. This fixes the PR comment so it only comments when the package is malicious, deprecated, has activity beneath the threshold or provenance beneath the threshold.
It also renames Trusty to Stacklok Insight in the PR comment.

Fixes #4944

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
