### PR TITLE
Limit datasources to public networks

### DIFF
--- a/internal/datasources/rest/handler_test.go
+++ b/internal/datasources/rest/handler_test.go
@@ -246,11 +246,12 @@ func Test_restHandler_Call(t *testing.T) {
 			tt.fields.endpointTmpl = server.URL + tt.fields.endpointTmpl
 
 			h := &restHandler{
-				endpointTmpl: tt.fields.endpointTmpl,
-				method:       tt.fields.method,
-				body:         tt.fields.body,
-				headers:      tt.fields.headers,
-				parse:        tt.fields.parse,
+				endpointTmpl:      tt.fields.endpointTmpl,
+				method:            tt.fields.method,
+				body:              tt.fields.body,
+				headers:           tt.fields.headers,
+				parse:             tt.fields.parse,
+				testOnlyTransport: http.DefaultTransport,
 			}
 			got, err := h.Call(context.Background(), nil, tt.args.args)
 			if tt.wantErr {


### PR DESCRIPTION
# Summary

Only allow datasources to fetch from public services, rather than fetching content from private IP resources.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Unit testing (needed to override tests).  This is also in place for `http.send` already (tested manually).

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
