### PR TITLE
Run tests that set env sequentially

### DIFF
--- a/internal/util/cli/cli_test.go
+++ b/internal/util/cli/cli_test.go
@@ -12,8 +12,9 @@ import (
 )
 
 // TestGetConfigDirPath tests the GetConfigDirPath function
+//
+//nolint:paralleltest
 func TestGetConfigDirPath(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name           string
 		envVar         string
@@ -35,8 +36,8 @@ func TestGetConfigDirPath(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		//nolint:paralleltest
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			setEnvVar(t, XdgConfigHomeEnvVar, tt.envVar)
 			path, err := cli.GetConfigDirPath()
 			if (err != nil) != tt.expectingError {

--- a/internal/util/cli/credentials_test.go
+++ b/internal/util/cli/credentials_test.go
@@ -44,8 +44,9 @@ func setEnvVar(t *testing.T, env string, value string) {
 }
 
 // TestGetGrpcConnection tests the GetGrpcConnection function
+//
+//nolint:paralleltest
 func TestGetGrpcConnection(t *testing.T) {
-	t.Parallel()
 	// authTokenMutex := &sync.Mutex{}
 	tests := []struct {
 		name          string
@@ -91,7 +92,6 @@ func TestGetGrpcConnection(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			setEnvVar(t, cli.MinderAuthTokenEnvVar, tt.envToken)
 			conn, err := cli.GetGrpcConnection(tt.grpcHost, tt.grpcPort, tt.allowInsecure, tt.issuerUrl, tt.clientId)
 			if (err != nil) != tt.expectedError {
@@ -148,9 +148,9 @@ func TestSaveCredentials(t *testing.T) {
 }
 
 // TestRemoveCredentials tests the RemoveCredentials function
+//
+//nolint:paralleltest
 func TestRemoveCredentials(t *testing.T) {
-	t.Parallel()
-
 	// Create a temporary directory
 	testDir := t.TempDir()
 	setEnvVar(t, XdgConfigHomeEnvVar, testDir)
@@ -182,8 +182,9 @@ func TestRemoveCredentials(t *testing.T) {
 }
 
 // TestRefreshCredentials tests the RefreshCredentials function
+//
+//nolint:paralleltest
 func TestRefreshCredentials(t *testing.T) {
-	t.Parallel()
 	// Create a temporary directory
 	testDir := t.TempDir()
 
@@ -232,8 +233,6 @@ func TestRefreshCredentials(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				fmt.Fprintln(w, tt.responseBody)
@@ -260,9 +259,9 @@ func TestRefreshCredentials(t *testing.T) {
 }
 
 // TestLoadCredentials tests the LoadCredentials function
+//
+//nolint:paralleltest
 func TestLoadCredentials(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name           string
 		fileContent    string
@@ -293,7 +292,6 @@ func TestLoadCredentials(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			testDir := t.TempDir()
 			setEnvVar(t, XdgConfigHomeEnvVar, testDir)
 			// Create the minder directory inside the temp directory


### PR DESCRIPTION
# Summary

This is an attempt to fix the tests that are continuously failing, for example https://github.com/mindersec/minder/actions/runs/13108294785/job/36571707787

This should indicate if the lock in `setEnvVar` is the cause, or if it's something else.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
