### PR TITLE
Update maintainer list to point to community

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,7 +10,7 @@ currently has a two-tier contributor structure:
 
 ## Contributors
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for a desrciption of how to get started
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for a description of how to get started
 contributing to Minder.
 
 ## Requirements for Becoming a Maintainer
@@ -59,23 +59,4 @@ As a maintainer, you will have the following responsibilities:
 
 ## Maintainers List
 
-The current list of maintainers is:
-
-- @JAORMX (Stacklok)
-- @jhrozek (Stacklok)
-- @rdimitrov (Stacklok)
-- @dmjb (Stacklok)
-- @evankanderson (Stacklok)
-- @eleftherias (Stacklok)
-- @yrobla (Stacklok)
-- @lukehinds (Stacklok)
-- @blkt (Stacklok)
-- @puerco (Stacklok)
-- @teodor-yanev (Stacklok)
-- @Vyom-Yadav (Canonical)
-
-Assignment of permissions for these maintainers is currently privately managed
-by Stacklok as a matter of circumstance; changes to this list will need a
-Stacker to apply some private automation to grant the privileges, until we find
-a different approach (for example, donation to a foundation, which would have
-their own automation).
+See https://github.com/mindersec/community/tree/main/MAINTAINERS.md for the current list of maintainers.


### PR DESCRIPTION
# Summary

We managed to duplicate MAINTAINERS.md when we created `mindersec/community`.  Point to the maintainer list in that repo.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [x] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

N/A

# Review Checklist:

- [ ] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
