### PR TITLE
Fix GRPCRoute definition based on experimental evidence

### DIFF
--- a/deployment/helm/templates/routes.yaml
+++ b/deployment/helm/templates/routes.yaml
@@ -21,8 +21,11 @@ spec:
       name: minder-grpc
       port: !!int "{{ .Values.service.grpcPort }}"
       weight: 1
-    # If no matches are specified, the implementation MUST match every gRPC request.
-    matches: []
+    # Envoy-Gateway requires that the matches be non-empty to match GRPC, but allows for regex matches.
+    matches:
+    - method:
+        type: RegularExpression
+        service: ".*"
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute


### PR DESCRIPTION
# Summary

With the previous definition, either as:

```yaml
rules:
- matches: []
```

or

```yaml
rules:
- backendRefs: ...
  # no matches
```

I would get an error:

```
Details: unexpected HTTP status code received from server: 404 (Not Found); transport: received unexpected content-type "application/json"
```

This configuration seems to successfully route traffic (proven with the following config):

```yaml
grpc_server:
  host: api.custcodian.dev
  port: 443
  insecure: false
identity:
  cli:
    issuer_url: https://auth.custcodian.dev
    client_id: minder-cli
    realm: login
```


## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual testing on `custcodian.dev` domain.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
