### PR TITLE
Move email templates to data

### DIFF
--- a/cmd/server/kodata/templates/invite-email.html.tmpl
+++ b/cmd/server/kodata/templates/invite-email.html.tmpl
@@ -1,38 +1,3 @@
-// SPDX-FileCopyrightText: Copyright 2024 The Minder Authors
-// SPDX-License-Identifier: Apache-2.0
-
-package email
-
-import "html/template"
-
-// validate that the templates compile
-var (
-	_ = template.Must(template.New("body-invite-text").Parse(bodyText))
-	_ = template.Must(template.New("body-invite-html").Parse(bodyHTML))
-)
-
-//nolint:lll
-const (
-	// bodyText is the text body of the email
-	bodyText = `
-{{.AdminName}} has invited you to become {{.RoleName}} in the {{.OrganizationName}} organization in Minder by Stacklok.
-
-View Invitation: {{.InvitationURL}}
-
-Once you accept, you’ll be able to {{.RoleVerb}} the {{.OrganizationName}} organization in Minder by Stacklok.
-
-This invitation was sent to {{.RecipientEmail}}. If you were not expecting it, you can ignore this email.
-
-Minder by Stacklok is an open source platform that helps development teams and open source communities build more secure software, and prove to others that what they’ve built is secure.
-
-Terms and Conditions: {{.TermsURL}} Privacy: {{.PrivacyURL}}
-
-Sign in to Minder: {{.SignInURL}}
-
-Stacklok
-`
-	// bodyHTML is the HTML body of the email
-	bodyHTML = `
 <div
   style="
     background-color: #f5fbff;
@@ -302,5 +267,3 @@ Stacklok
     </tbody>
   </table>
 </div>
-`
-)

--- a/cmd/server/kodata/templates/invite-email.txt.tmpl
+++ b/cmd/server/kodata/templates/invite-email.txt.tmpl
@@ -1,0 +1,15 @@
+{{.AdminName}} has invited you to become {{.RoleName}} in the {{.OrganizationName}} organization in Minder by Stacklok.
+
+View Invitation: {{.InvitationURL}}
+
+Once you accept, you’ll be able to {{.RoleVerb}} the {{.OrganizationName}} organization in Minder by Stacklok.
+
+This invitation was sent to {{.RecipientEmail}}. If you were not expecting it, you can ignore this email.
+
+Minder by Stacklok is an open source platform that helps development teams and open source communities build more secure software, and prove to others that what they’ve built is secure.
+
+Terms and Conditions: {{.TermsURL}} Privacy: {{.PrivacyURL}}
+
+Sign in to Minder: {{.SignInURL}}
+
+Stacklok

--- a/internal/invites/service_test.go
+++ b/internal/invites/service_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -163,6 +164,8 @@ func TestUpdateInvite(t *testing.T) {
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
 			t.Parallel()
+			// Needed for loading email templates
+			assert.NoError(t, os.Setenv("KO_DATA_PATH", "../../cmd/server/kodata"))
 
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
@@ -240,6 +243,8 @@ func TestRemoveInvite(t *testing.T) {
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
 			t.Parallel()
+			// Needed for loading email templates
+			assert.NoError(t, os.Setenv("KO_DATA_PATH", "../../cmd/server/kodata"))
 
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()


### PR DESCRIPTION
# Summary

The current email template contents are both hard-coded and Stacklok-specific.  Move these to `kodata`, so that other users can customize their own email templates.

I also noticed that we were using `NewSafeHTMLTemplate` for the text body, and re-parsing the templates every time -- this is now moved to module-level initialization (this means you need to restart the server to pick up new templates, but this seems reasonable given that other config requires a restart

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Unit tests (so far) -- will do some integration testing after merge.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
