### PR TITLE
Determine authentication host based on WWW-Authenticate header

### DIFF
--- a/cmd/cli/app/auth/auth_token.go
+++ b/cmd/cli/app/auth/auth_token.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"google.golang.org/grpc"
 
 	"github.com/mindersec/minder/internal/util/cli"
 	"github.com/mindersec/minder/pkg/config"
@@ -39,11 +40,13 @@ func TokenCommand(cmd *cobra.Command, _ []string) error {
 	// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
 	cmd.SilenceUsage = true
 
+	grpcCfg := clientConfig.GRPCClientConfig
+	opts := []grpc.DialOption{grpcCfg.TransportCredentialsOption()}
 	// save credentials
 	issuerUrl := clientConfig.Identity.CLI.IssuerUrl
 	clientId := clientConfig.Identity.CLI.ClientId
 	realm := clientConfig.Identity.CLI.Realm
-	creds, err := cli.GetToken(issuerUrl, realm, clientId)
+	creds, err := cli.GetToken(grpcCfg.GetGRPCAddress(), opts, issuerUrl, realm, clientId)
 	if err != nil {
 		cmd.Printf("Error getting token: %v\n", err)
 		if errors.Is(err, os.ErrNotExist) || errors.Is(err, cli.ErrGettingRefreshToken) {

--- a/cmd/cli/app/auth/offline_token/offline_use.go
+++ b/cmd/cli/app/auth/offline_token/offline_use.go
@@ -55,11 +55,18 @@ func offlineUseCommand(_ context.Context, cmd *cobra.Command, _ []string, _ *grp
 	// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
 	cmd.SilenceUsage = true
 
+	grpcCfg := clientConfig.GRPCClientConfig
+	opts := []grpc.DialOption{grpcCfg.TransportCredentialsOption()}
 	issuerUrlStr := clientConfig.Identity.CLI.IssuerUrl
 	clientID := clientConfig.Identity.CLI.ClientId
 	realm := clientConfig.Identity.CLI.Realm
 
-	creds, err := cli.RefreshCredentials(tok, issuerUrlStr, realm, clientID)
+	realmUrl, err := cli.GetRealmUrl(grpcCfg.GetGRPCAddress(), opts, issuerUrlStr, realm)
+	if err != nil {
+		return fmt.Errorf("couldn't get realm URL: %v", err)
+	}
+
+	creds, err := cli.RefreshCredentials(tok, realmUrl, clientID)
 	if err != nil {
 		return fmt.Errorf("couldn't fetch credentials: %v", err)
 	}

--- a/cmd/cli/app/root.go
+++ b/cmd/cli/app/root.go
@@ -103,6 +103,7 @@ func init() {
 func initConfig() {
 	viper.SetEnvPrefix("minder")
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
+	config.SetViperStructDefaults(viper.GetViper(), "", clientconfig.Config{})
 
 	// Get the config flag value directly to ensure we catch explicitly specified configs
 	configFlag := viper.GetString("config")

--- a/internal/controlplane/handlers_token.go
+++ b/internal/controlplane/handlers_token.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -27,7 +28,7 @@ import (
 )
 
 // TokenValidationInterceptor is a server interceptor that validates the bearer token
-func TokenValidationInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo,
+func (s *Server) TokenValidationInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler) (any, error) {
 
 	opts, err := optionsForMethod(info)
@@ -49,6 +50,14 @@ func TokenValidationInterceptor(ctx context.Context, req interface{}, info *grpc
 	if err != nil {
 		if statusErr, ok := status.FromError(err); ok {
 			return nil, util.FromRpcError(statusErr)
+		}
+		realmUrl := s.cfg.Identity.Server.GetRealmURL()
+		// Provide a WWW-Authenticate header hint for authentication if configured.
+		if realmUrl.Host != "" && s.cfg.Identity.Server.Scope != "" {
+			authenticateHeader := fmt.Sprintf(`Bearer realm=%q, scope=%q`,
+				realmUrl.String(), s.cfg.Identity.Server.Scope)
+			authHeader := metadata.New(map[string]string{"WWW-Authenticate": authenticateHeader})
+			grpc.SendHeader(ctx, authHeader)
 		}
 		return nil, status.Errorf(codes.Unauthenticated, "no auth token: %v", err)
 	}

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -254,7 +254,7 @@ func (s *Server) StartGRPCServer(ctx context.Context) error {
 		// response.
 		logger.RequestIDInterceptor("request-id"),
 		logger.Interceptor(s.cfg.LoggingConfig),
-		TokenValidationInterceptor,
+		s.TokenValidationInterceptor,
 		EntityContextProjectInterceptor,
 		ProjectAuthorizationInterceptor,
 		recovery.UnaryServerInterceptor(recovery.WithRecoveryHandlerContext(recoveryHandler)),

--- a/internal/util/cli/credentials_test.go
+++ b/internal/util/cli/credentials_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/mindersec/minder/internal/util/cli"
+	"github.com/mindersec/minder/pkg/config/client"
 )
 
 var (
@@ -93,7 +94,12 @@ func TestGetGrpcConnection(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			setEnvVar(t, cli.MinderAuthTokenEnvVar, tt.envToken)
-			conn, err := cli.GetGrpcConnection(tt.grpcHost, tt.grpcPort, tt.allowInsecure, tt.issuerUrl, "stacklok", tt.clientId)
+			grpcCfg := client.GRPCClientConfig{
+				Host: 		 tt.grpcHost,
+				Port: 		 tt.grpcPort,
+				Insecure: tt.allowInsecure,
+			}
+			conn, err := cli.GetGrpcConnection(grpcCfg, tt.issuerUrl, "stacklok", tt.clientId)
 			if (err != nil) != tt.expectedError {
 				t.Errorf("expected error: %v, got: %v", tt.expectedError, err)
 			}
@@ -241,7 +247,7 @@ func TestRefreshCredentials(t *testing.T) {
 
 			tt.issuerUrl = server.URL
 
-			result, err := cli.RefreshCredentials(tt.refreshToken, tt.issuerUrl, "stacklok", tt.clientId)
+			result, err := cli.RefreshCredentials(tt.refreshToken, tt.issuerUrl, tt.clientId)
 			if tt.expectedError != "" {
 				if err == nil || err.Error() != tt.expectedError {
 					t.Errorf("expected error %v, got %v", tt.expectedError, err)

--- a/internal/util/cli/credentials_test.go
+++ b/internal/util/cli/credentials_test.go
@@ -95,8 +95,8 @@ func TestGetGrpcConnection(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			setEnvVar(t, cli.MinderAuthTokenEnvVar, tt.envToken)
 			grpcCfg := client.GRPCClientConfig{
-				Host: 		 tt.grpcHost,
-				Port: 		 tt.grpcPort,
+				Host:     tt.grpcHost,
+				Port:     tt.grpcPort,
 				Insecure: tt.allowInsecure,
 			}
 			conn, err := cli.GetGrpcConnection(grpcCfg, tt.issuerUrl, "stacklok", tt.clientId)

--- a/internal/util/cli/rpc_client.go
+++ b/internal/util/cli/rpc_client.go
@@ -67,10 +67,10 @@ func GrpcForCommand(cmd *cobra.Command, v *viper.Viper) (*grpc.ClientConn, error
 		return nil, fmt.Errorf("unable to read config: %w", err)
 	}
 
-	grpcHost := clientConfig.GRPCClientConfig.Host
-	grpcPort := clientConfig.GRPCClientConfig.Port
-	insecureDefault := grpcHost == "localhost" || grpcHost == "127.0.0.1" || grpcHost == "::1"
-	allowInsecure := clientConfig.GRPCClientConfig.Insecure || insecureDefault
+	// grpcHost := clientConfig.GRPCClientConfig.Host
+	// grpcPort := clientConfig.GRPCClientConfig.Port
+	// insecureDefault := grpcHost == "localhost" || grpcHost == "127.0.0.1" || grpcHost == "::1"
+	// allowInsecure := clientConfig.GRPCClientConfig.Insecure || insecureDefault
 
 	issuerUrl := clientConfig.Identity.CLI.IssuerUrl
 	clientId := clientConfig.Identity.CLI.ClientId
@@ -84,9 +84,10 @@ func GrpcForCommand(cmd *cobra.Command, v *viper.Viper) (*grpc.ClientConn, error
 	}
 
 	return GetGrpcConnection(
-		grpcHost,
-		grpcPort,
-		allowInsecure,
+		clientConfig.GRPCClientConfig,
+		// grpcHost,
+		// grpcPort,
+		// allowInsecure,
 		issuerUrl,
 		realm,
 		clientId,
@@ -104,7 +105,9 @@ func EnsureCredentials(cmd *cobra.Command, _ []string) error {
 		return MessageAndError("Unable to read config", err)
 	}
 
-	_, err = GetToken(clientConfig.Identity.CLI.IssuerUrl,
+	_, err = GetToken(clientConfig.GRPCClientConfig.GetGRPCAddress(),
+		[]grpc.DialOption{clientConfig.GRPCClientConfig.TransportCredentialsOption()},
+		clientConfig.Identity.CLI.IssuerUrl,
 		clientConfig.Identity.CLI.Realm,
 		clientConfig.Identity.CLI.ClientId)
 	if err != nil { // or token is expired?

--- a/internal/util/cli/rpc_client.go
+++ b/internal/util/cli/rpc_client.go
@@ -239,11 +239,11 @@ func Login(
 		return nil, MessageAndError("Error getting random port", err)
 	}
 
-	parsedURL, err := url.Parse(fmt.Sprintf("http://localhost:%v", port))
-	if err != nil {
-		return nil, MessageAndError("Error parsing callback URL", err)
+	redirectURI := &url.URL{
+		Scheme: "http",
+		Host:   fmt.Sprintf("localhost:%v", port),
 	}
-	redirectURI := parsedURL.JoinPath(callbackPath)
+	redirectURI = redirectURI.JoinPath(callbackPath)
 
 	provider, err := rp.NewRelyingPartyOIDC(ctx, realmUrl, clientID, "", redirectURI.String(), scopes, options...)
 	if err != nil {

--- a/internal/util/cli/rpc_client.go
+++ b/internal/util/cli/rpc_client.go
@@ -63,7 +63,7 @@ func requestIDInterceptor(printer func(string, ...interface{})) grpc.UnaryClient
 // GrpcForCommand is a helper for getting a testing connection from cobra flags
 func GrpcForCommand(cmd *cobra.Command, v *viper.Viper) (*grpc.ClientConn, error) {
 	clientConfig, err := config.ReadConfigFromViper[clientconfig.Config](v)
-	if err != nil {
+	if err != nil || clientConfig == nil {
 		return nil, fmt.Errorf("unable to read config: %w", err)
 	}
 
@@ -93,7 +93,7 @@ func EnsureCredentials(cmd *cobra.Command, _ []string) error {
 	ctx := context.Background()
 
 	clientConfig, err := config.ReadConfigFromViper[clientconfig.Config](viper.GetViper())
-	if err != nil {
+	if err != nil || clientConfig == nil {
 		return MessageAndError("Unable to read config", err)
 	}
 
@@ -182,6 +182,9 @@ func Login(
 	extraScopes []string,
 	skipBroswer bool,
 ) (*oidc.Tokens[*oidc.IDTokenClaims], error) {
+	if cfg == nil {
+		return nil, errors.New("client config is nil")
+	}
 	grpcCfg := cfg.GRPCClientConfig
 	opts := []grpc.DialOption{grpcCfg.TransportCredentialsOption()}
 	issuerUrlStr := cfg.Identity.CLI.IssuerUrl

--- a/pkg/config/client/config.go
+++ b/pkg/config/client/config.go
@@ -5,8 +5,14 @@
 package client
 
 import (
+	"crypto/tls"
+	"fmt"
+
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/mindersec/minder/internal/constants"
 	"github.com/mindersec/minder/pkg/config"
@@ -14,15 +20,15 @@ import (
 
 // Config is the configuration for the minder cli
 type Config struct {
-	GRPCClientConfig config.GRPCClientConfig `mapstructure:"grpc_server" yaml:"grpc_server" json:"grpc_server"`
-	Identity         IdentityConfigWrapper   `mapstructure:"identity" yaml:"identity" json:"identity"`
+	GRPCClientConfig GRPCClientConfig      `mapstructure:"grpc_server" yaml:"grpc_server" json:"grpc_server"`
+	Identity         IdentityConfigWrapper `mapstructure:"identity" yaml:"identity" json:"identity"`
 	// Project is the current project
 	Project string `mapstructure:"project" yaml:"project" json:"project"`
 }
 
 // RegisterMinderClientFlags registers the flags for the minder cli
 func RegisterMinderClientFlags(v *viper.Viper, flags *pflag.FlagSet) error {
-	if err := config.RegisterGRPCClientConfigFlags(v, flags); err != nil {
+	if err := RegisterGRPCClientConfigFlags(v, flags); err != nil {
 		return err
 	}
 
@@ -39,4 +45,51 @@ func registerClientIdentityConfigFlags(v *viper.Viper, flags *pflag.FlagSet) err
 
 	return config.BindConfigFlag(v, flags, "identity.cli.client_id", "identity-client", "minder-cli",
 		"Identity server client ID", flags.String)
+}
+
+// GRPCClientConfig is the configuration for a service to connect to minder gRPC server
+type GRPCClientConfig struct {
+	// Host is the host to connect to
+	Host string `mapstructure:"host" yaml:"host" json:"host" default:"api.stacklok.com"`
+
+	// Port is the port to connect to
+	Port int `mapstructure:"port" yaml:"port" json:"port" default:"443"`
+
+	// Insecure is whether to allow establishing insecure connections
+	Insecure bool `mapstructure:"insecure" yaml:"insecure" json:"insecure" default:"false"`
+}
+
+// RegisterGRPCClientConfigFlags registers the flags for the gRPC client
+func RegisterGRPCClientConfigFlags(v *viper.Viper, flags *pflag.FlagSet) error {
+	err := config.BindConfigFlag(v, flags, "grpc_server.host", "grpc-host", constants.MinderGRPCHost,
+		"Server host", flags.String)
+	if err != nil {
+		return err
+	}
+
+	err = config.BindConfigFlag(v, flags, "grpc_server.port", "grpc-port", 443,
+		"Server port", flags.Int)
+	if err != nil {
+		return err
+	}
+
+	return config.BindConfigFlag(v, flags, "grpc_server.insecure", "grpc-insecure", false,
+		"Allow establishing insecure connections", flags.Bool)
+}
+
+func (c GRPCClientConfig) GetGRPCAddress() string {
+	return fmt.Sprintf("%s: %d", c.Host, c.Port)
+}
+
+func (c GRPCClientConfig) TransportCredentialsOption() grpc.DialOption {
+	insecureDefault := c.Host == "localhost" || c.Host == "127.0.0.1" || c.Host == "::1"
+	allowInsecure := c.Insecure || insecureDefault
+
+	if allowInsecure {
+		return grpc.WithTransportCredentials(insecure.NewCredentials())
+	}
+	return grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+		MinVersion: tls.VersionTLS13,
+		ServerName: c.Host,
+	}))
 }

--- a/pkg/config/client/config.go
+++ b/pkg/config/client/config.go
@@ -77,10 +77,13 @@ func RegisterGRPCClientConfigFlags(v *viper.Viper, flags *pflag.FlagSet) error {
 		"Allow establishing insecure connections", flags.Bool)
 }
 
+// GetGRPCAddress returns the formatted GRPC address of the server.
 func (c GRPCClientConfig) GetGRPCAddress() string {
 	return fmt.Sprintf("%s: %d", c.Host, c.Port)
 }
 
+// TransportCredentialsOption returns a gRPC dial option appropriate to the
+// configuration (either TLS with correct hostname, or without verification).
 func (c GRPCClientConfig) TransportCredentialsOption() grpc.DialOption {
 	insecureDefault := c.Host == "localhost" || c.Host == "127.0.0.1" || c.Host == "::1"
 	allowInsecure := c.Insecure || insecureDefault

--- a/pkg/config/common.go
+++ b/pkg/config/common.go
@@ -16,8 +16,6 @@ import (
 	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-
-	"github.com/mindersec/minder/internal/constants"
 )
 
 // DatabaseConfig is the configuration for the database
@@ -107,36 +105,6 @@ func RegisterDatabaseFlags(v *viper.Viper, flags *pflag.FlagSet) error {
 
 	return BindConfigFlagWithShort(
 		v, flags, "database.sslmode", "db-sslmode", "s", "disable", "Database sslmode", flags.StringP)
-}
-
-// GRPCClientConfig is the configuration for a service to connect to minder gRPC server
-type GRPCClientConfig struct {
-	// Host is the host to connect to
-	Host string `mapstructure:"host" yaml:"host" json:"host" default:"api.stacklok.com"`
-
-	// Port is the port to connect to
-	Port int `mapstructure:"port" yaml:"port" json:"port" default:"443"`
-
-	// Insecure is whether to allow establishing insecure connections
-	Insecure bool `mapstructure:"insecure" yaml:"insecure" json:"insecure" default:"false"`
-}
-
-// RegisterGRPCClientConfigFlags registers the flags for the gRPC client
-func RegisterGRPCClientConfigFlags(v *viper.Viper, flags *pflag.FlagSet) error {
-	err := BindConfigFlag(v, flags, "grpc_server.host", "grpc-host", constants.MinderGRPCHost,
-		"Server host", flags.String)
-	if err != nil {
-		return err
-	}
-
-	err = BindConfigFlag(v, flags, "grpc_server.port", "grpc-port", 443,
-		"Server port", flags.Int)
-	if err != nil {
-		return err
-	}
-
-	return BindConfigFlag(v, flags, "grpc_server.insecure", "grpc-insecure", false,
-		"Allow establishing insecure connections", flags.Bool)
 }
 
 // ReadKey reads a key from a file

--- a/pkg/config/server/identity.go
+++ b/pkg/config/server/identity.go
@@ -41,6 +41,8 @@ type IdentityConfig struct {
 	ClientSecretFile string `mapstructure:"client_secret_file"`
 	// Audience is the expected audience for JWT tokens (see OpenID spec)
 	Audience string `mapstructure:"audience" default:"minder"`
+	// Scope is the OAuth scope to request from the identity server to get the specified audience
+	Scope string `mapstructure:"scope" default:"minder-audience"`
 }
 
 // GetClientSecret returns the minder-server client secret
@@ -75,6 +77,14 @@ func (sic *IdentityConfig) Path(path ...string) (*url.URL, error) {
 // GetRealmPath returns a URL for the given path on the realm
 func (sic *IdentityConfig) GetRealmPath(path string) (*url.URL, error) {
 	return sic.Path("realms", sic.Realm, path)
+}
+
+func (sic *IdentityConfig) GetRealmURL() url.URL {
+	baseUrl, err := url.Parse(sic.IssuerClaim)
+	if err != nil {
+		return url.URL{}
+	}
+	return *baseUrl.JoinPath("protocol/openid-connect/token")
 }
 
 func (sic *IdentityConfig) getClient(ctx context.Context) (*http.Client, error) {

--- a/pkg/config/server/identity.go
+++ b/pkg/config/server/identity.go
@@ -79,12 +79,15 @@ func (sic *IdentityConfig) GetRealmPath(path string) (*url.URL, error) {
 	return sic.Path("realms", sic.Realm, path)
 }
 
+// GetRealmURL returns the URL for the WWW-Authenticate realm (used for OIDC discovery)
+// Clients should append "/.well-known/openid-configuration" to this URL, and use the
+// token_endpoint to get a token.
 func (sic *IdentityConfig) GetRealmURL() url.URL {
 	baseUrl, err := url.Parse(sic.IssuerClaim)
 	if err != nil {
 		return url.URL{}
 	}
-	return *baseUrl.JoinPath("protocol/openid-connect/token")
+	return *baseUrl
 }
 
 func (sic *IdentityConfig) getClient(ctx context.Context) (*http.Client, error) {


### PR DESCRIPTION
# Summary

With these changes, I no longer need to set the client-side `identity` parameters, and I can call Minder as:

```
./bin/minder --grpc-host localhost --grpc-port 8090 --grpc-insecure auth login
```

And it will log in with the local keycloak instance.  For other production instances, it should be possible to simply use `--grpc-host` to select them, and not need to explicitly know about their Keycloak configuration.  (And, at some point, it could be non-keycloak...)

On the server side, this requires something like the following `identity` configuration:

```yaml
identity:
  server:
    issuer_url: http://keycloak:8080 # Use http://localhost:8081 instead for running minder outside of docker-compose
    issuer_claim: http://localhost:8081/realms/stacklok # This needs to match keycloak's configured issuer, not the network path from Minder
    realm: stacklok
    client_id: minder-server
    client_secret: secret
    audience: minder
    scope: minder-audience
```

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual testing with a number of different configurations.  Along the way, I discovered that #5478 actually broke `minder auth login` for Stacklok / the default configuration, because we weren't setting the `mapstructure` defaults on the client, only on the server.  (There's a fix in here for that).

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
