### PR TITLE
Don't mix GRPCRoute with HTTPRoute on the same hostname

### DIFF
--- a/deployment/helm/templates/routes.yaml
+++ b/deployment/helm/templates/routes.yaml
@@ -1,31 +1,11 @@
 # SPDX-FileCopyrightText: Copyright 2023 The Minder Authors
 # SPDX-License-Identifier: Apache-2.0
 {{ if .Values.routes.enabled }}
-apiVersion: gateway.networking.k8s.io/v1
-kind: GRPCRoute
-metadata:
-  name: "{{- .Values.routes.name }}"
-  labels:
-    {{ include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
-spec:
-  parentRefs:
-    {{- if .Values.routes.parentRefs }}
-    {{- toYaml .Values.routes.parentRefs | nindent 4 }}
-    {{- end }}
-  hostnames:
-    - "{{ .Values.hostname }}"
-  rules:
-  - backendRefs:
-    - group: ""
-      kind: Service
-      name: minder-grpc
-      port: !!int "{{ .Values.service.grpcPort }}"
-      weight: 1
-    # Envoy-Gateway requires that the matches be non-empty to match GRPC, but allows for regex matches.
-    matches:
-    - method:
-        type: RegularExpression
-        service: ".*"
+// You would think we would want a GRPCRoute object to route gRPC traffic.
+// However, GRPC is a special dialect of HTTP/2, and Gateway-API does not
+// support mixing GRPC routes and HTTP routes on the same hostname (see
+// https://gateway-api.sigs.k8s.io/api-types/grpcroute/#cross-serving and
+// https://github.com/mindersec/minder/issues/5503).
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute


### PR DESCRIPTION
# Summary

Noticed this in staging with our tests, which use grpc-gateway to serve a Swagger (JSON) API.

This should work without the GRPCRoute using the HTTPRoute instead.

Fixes #5503

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

I haven't had a chance to test this yet; the cheapest test seemed to be to update the helm chart.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
