### PR TITLE
Fix GRPC routing as well as HTTP routing

### DIFF
--- a/deployment/helm/templates/routes.yaml
+++ b/deployment/helm/templates/routes.yaml
@@ -26,6 +26,16 @@ spec:
     - method:
         type: RegularExpression
         service: ".*"
+      # Only match binary GRPC requests; without this, you will run into HTTP 415 errors
+      # when the route tries to match Swagger API requests to e.g. /api/v1/user or other
+      # endpoints.  See also the warnings in the Gateway API documentation, despite the
+      # fact that GRPC requests _are_ valid HTTP/2 requests, we get 404 error when only
+      # using the HTTPRoute rule.
+      # https://gateway-api.sigs.k8s.io/api-types/grpcroute/#cross-serving
+      headers:
+      - name: content-type
+        type: RegularExpression
+        value: "^application/grpc.*"
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/deployment/helm/templates/routes.yaml
+++ b/deployment/helm/templates/routes.yaml
@@ -1,11 +1,31 @@
 # SPDX-FileCopyrightText: Copyright 2023 The Minder Authors
 # SPDX-License-Identifier: Apache-2.0
 {{ if .Values.routes.enabled }}
-# You would think we would want a GRPCRoute object to route gRPC traffic.
-# However, GRPC is a special dialect of HTTP/2, and Gateway-API does not
-# support mixing GRPC routes and HTTP routes on the same hostname (see
-# https://gateway-api.sigs.k8s.io/api-types/grpcroute/#cross-serving and
-# https://github.com/mindersec/minder/issues/5503).
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: "{{- .Values.routes.name }}"
+  labels:
+    {{ include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+spec:
+  parentRefs:
+    {{- if .Values.routes.parentRefs }}
+    {{- toYaml .Values.routes.parentRefs | nindent 4 }}
+    {{- end }}
+  hostnames:
+    - "{{ .Values.hostname }}"
+  rules:
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: minder-grpc
+      port: !!int "{{ .Values.service.grpcPort }}"
+      weight: 1
+    # Envoy-Gateway requires that the matches be non-empty to match GRPC, but allows for regex matches.
+    matches:
+    - method:
+        type: RegularExpression
+        service: ".*"
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute


### PR DESCRIPTION
# Summary

This will teach me to read docs and assume that they know what they are talking about (spoiler: it did not).

It turns out that without a GRPCRoute, we get _different_ strange errors of the form:

```
Details: error retrieving user rpc error: code = Unimplemented desc = unexpected HTTP status code received from server: 404 (Not Found); transport: received unexpected content-type "application/json"
```

Fixes #5503

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

I used some manual route loading on `api.custcodian.dev` to test the following:

```
./bin/minder --grpc-host api.custcodian.dev auth login

curl -i https://api.custcodian.dev/api/v1/user
```

Both seem to be working correctly with this configuration, which _should_ enable the robot tests and the UI to do the same.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
