### PR TITLE
Fix token URL for offline token use

### DIFF
--- a/cmd/cli/app/auth/offline_token/offline_use.go
+++ b/cmd/cli/app/auth/offline_token/offline_use.go
@@ -7,6 +7,7 @@ package offline_token
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -65,6 +66,14 @@ func offlineUseCommand(_ context.Context, cmd *cobra.Command, _ []string, _ *grp
 	if err != nil {
 		return fmt.Errorf("couldn't get realm URL: %v", err)
 	}
+
+	// TODO: use the proper well-known discovery via "./.well-known/openid-configuration"
+	// possibly with the rp.NewRelyingPartyOIDC from zitadel
+	parsedUrl, err := url.Parse(realmUrl)
+	if err != nil {
+		return fmt.Errorf("couldn't parse realm URL %s: %v", realmUrl, err)
+	}
+	realmUrl = parsedUrl.JoinPath("protocol/openid-connect/token").String()
 
 	creds, err := cli.RefreshCredentials(tok, realmUrl, clientID)
 	if err != nil {


### PR DESCRIPTION
# Summary

I broke the token exchange URL for `offline token use` in #5502 when I changed `RefreshCredentials` to no longer append `protocol/openid-connect/token` to the supplied URL, but I forgot to fix up `offline_use.go` properly.  (I fetched the realm URL properly, but I didn't move the token URL addition to the outer layer.)  Added a TODO on cleanup to match the one in `GetToken` in the `internal/util/cli` library.

Our smoke tests use this, so `minder@main` was failing.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
