### PR TITLE
Fix formatting of GRPC client address

### DIFF
--- a/pkg/config/client/config.go
+++ b/pkg/config/client/config.go
@@ -79,7 +79,7 @@ func RegisterGRPCClientConfigFlags(v *viper.Viper, flags *pflag.FlagSet) error {
 
 // GetGRPCAddress returns the formatted GRPC address of the server.
 func (c GRPCClientConfig) GetGRPCAddress() string {
-	return fmt.Sprintf("%s: %d", c.Host, c.Port)
+	return fmt.Sprintf("%s:%d", c.Host, c.Port)
 }
 
 // TransportCredentialsOption returns a gRPC dial option appropriate to the


### PR DESCRIPTION
# Summary

Apparently I let GenAI have a bit too much fun, and it generated GRPC addresses like `staging.stacklok.dev: 443`.  Remarkably, this appears to _work_ on Darwin (MacOS), Windows, and Linux according to manual testing, but it still seems weird.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Tested manually.  Will try to add some unit tests for this at some point, though it's technically "working" now...

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
