### PR TITLE
Move email file parsing (and env setting) to TestMain to reduce flakes

### DIFF
--- a/internal/invites/service_test.go
+++ b/internal/invites/service_test.go
@@ -30,6 +30,22 @@ import (
 	mockevents "github.com/mindersec/minder/pkg/eventer/interfaces/mock"
 )
 
+func TestMain(m *testing.M) {
+	// Needed for loading email templates
+	err := os.Setenv("KO_DATA_PATH", "../../cmd/server/kodata")
+	if err != nil {
+		fmt.Printf("error setting KO_DATA_PATH: %v\n", err)
+		os.Exit(1)
+	}
+	_, err = email.NewMessage(context.Background(), "j@example.com", "http://example.com/invite", "http://api.example.com/", "admin", "Example", "Joe")
+	if err != nil {
+		fmt.Printf("error creating message: %v\n", err)
+		os.Exit(1)
+	}
+
+	m.Run()
+}
+
 func TestCreateInvite(t *testing.T) {
 	t.Parallel()
 
@@ -164,8 +180,6 @@ func TestUpdateInvite(t *testing.T) {
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
 			t.Parallel()
-			// Needed for loading email templates
-			assert.NoError(t, os.Setenv("KO_DATA_PATH", "../../cmd/server/kodata"))
 
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
@@ -243,8 +257,6 @@ func TestRemoveInvite(t *testing.T) {
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
 			t.Parallel()
-			// Needed for loading email templates
-			assert.NoError(t, os.Setenv("KO_DATA_PATH", "../../cmd/server/kodata"))
 
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()


### PR DESCRIPTION
# Summary

I've seen a bunch of flakes in `./internal/invites` tests after I moved the templates to be read from the filesystem in an `initOnce`.  Move the fetch and parse of these files to `TestMain`, which runs before the tests, to hopefully trigger the initialization before other tests are running around affecting things.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Ran `go test -count 2 ./...` and checked that these tests passed (there are a few other that aren't multi-count safe that I will try to fix in the future).

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
