### PR TITLE
Fix detected race in interna/providers/github/webhook by locking channel access

### DIFF
--- a/internal/util/testqueue/passthroughqueue.go
+++ b/internal/util/testqueue/passthroughqueue.go
@@ -5,6 +5,7 @@
 package testqueue
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/ThreeDotsLabs/watermill/message"
@@ -13,8 +14,9 @@ import (
 // PassthroughQueue is a queue that passes messages through.
 // It's only useful for testing.
 type PassthroughQueue struct {
-	ch chan *message.Message
-	t  *testing.T
+	ch     chan *message.Message
+	chLock sync.Mutex
+	t      *testing.T
 }
 
 // NewPassthroughQueue creates a new PassthroughQueue
@@ -29,18 +31,24 @@ func NewPassthroughQueue(t *testing.T) *PassthroughQueue {
 
 // GetQueue returns the queue
 func (q *PassthroughQueue) GetQueue() <-chan *message.Message {
+	q.chLock.Lock()
+	defer q.chLock.Unlock()
 	return q.ch
 }
 
 // Pass passes a message through the queue
 func (q *PassthroughQueue) Pass(msg *message.Message) error {
 	q.t.Logf("Passing message through queue: %s", msg.UUID)
+	q.chLock.Lock()
+	defer q.chLock.Unlock()
 	q.ch <- msg
 	return nil
 }
 
 // Close frees closes the channel used as queue.
 func (q *PassthroughQueue) Close() error {
+	q.chLock.Lock()
+	defer q.chLock.Unlock()
 	close(q.ch)
 	return nil
 }


### PR DESCRIPTION
# Summary

Ref: https://github.com/mindersec/minder/actions/runs/14067172052/job/39392502845

The unit tests failed due to a detected data race:

```
 ==================
  WARNING: DATA RACE
  Write at 0x00c0008b5b30 by goroutine 44:
    runtime.closechan()
        /opt/hostedtoolcache/go/1.23.7/x64/src/runtime/chan.go:397 +0x0
    github.com/mindersec/minder/internal/util/testqueue.(*PassthroughQueue).Close()
        /home/runner/work/minder/minder/internal/util/testqueue/passthroughqueue.go:44 +0xa4
    github.com/mindersec/minder/internal/providers/github/webhook.(*UnitTestSuite).TestHandleGitHubAppWebHook.func5.deferwrap3()
        /home/runner/work/minder/minder/internal/providers/github/webhook/handlers_githubwebhooks_test.go:3266 +0x1f
...
Previous read at 0x00c0008b5b30 by goroutine 459:
    runtime.chansend()
        /opt/hostedtoolcache/go/1.23.7/x64/src/runtime/chan.go:171 +0x0
    github.com/mindersec/minder/internal/util/testqueue.(*PassthroughQueue).Pass()
        /home/runner/work/minder/minder/internal/util/testqueue/passthroughqueue.go:38 +0x136
    github.com/mindersec/minder/internal/util/testqueue.(*PassthroughQueue).Pass-fm()
        <autogenerated>:1 +0x1f
    github.com/mindersec/minder/internal/events.(*eventer).Register.func1()
```

Because the channel write happens on a background eventing thread, the channel read (for send) and write (for close) can race each other.  This might be harmless in practice (though https://go.dev/tour/concurrency/4 suggests _**Note**: Only the sender should close a channel, never the receiver. Sending on a closed channel will cause a panic._), but since this is test code anyway, let's just lock the channel access to make the Go race detector happy.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

I ran `go test -race -count 20 ./internal/providers/github/webhook`, and didn't see any race warnings.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
