### PR TITLE
Add profile export and top-level apply commands

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -17,5 +17,5 @@ jobs:
       - name: Check license headers
         run: |
           set -e
-          addlicense -l apache -c 'Stacklok, Inc' -v -ignore "pkg/generated/*" -ignore "**/database/query/**" -ignore "internal/db/*" -ignore "docs/docs/**" -ignore "docs/src/**" -ignore "docs/static/**" -ignore "pkg/controlplane/policy_types/**" -ignore "docs/build/**" -ignore "examples/**" -ignore "internal/auth/keycloak/client/keycloak-api.yaml" *
+          addlicense -l apache -s=only -c 'The Minder Authors' -v -ignore "pkg/generated/*" -ignore "**/database/query/**" -ignore "internal/db/*" -ignore "docs/docs/**" -ignore "docs/src/**" -ignore "docs/static/**" -ignore "pkg/controlplane/policy_types/**" -ignore "docs/build/**" -ignore "examples/**" -ignore "internal/auth/keycloak/client/keycloak-api.yaml" -ignore "**/testdata/**" *
           git diff --exit-code

--- a/cmd/cli/app/apply.go
+++ b/cmd/cli/app/apply.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright 2023 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"google.golang.org/grpc"
+
+	"github.com/mindersec/minder/internal/util/cli"
+	"github.com/mindersec/minder/pkg/api"
+	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
+	"github.com/mindersec/minder/pkg/fileconvert"
+)
+
+var applyCmd = &cobra.Command{
+	Use:   "apply",
+	Short: "Apply multiple minder resources",
+	Long:  `The apply subcommand lets you apply multiple Minder resources at once.`,
+	RunE:  cli.GRPCClientWrapRunE(applyCommand),
+}
+
+// applyCommand is the general-purpose "apply" subcommand
+func applyCommand(ctx context.Context, cmd *cobra.Command, args []string, conn *grpc.ClientConn) error {
+	// Step 1: Collect inputs, by reading files or directories.  Use the "-f" flag if set, positional arguments otherwise.
+	fileNames := args
+	if len(viper.GetStringSlice("file")) > 0 {
+		fileNames = viper.GetStringSlice("file")
+	}
+	objects, err := fileconvert.ResourcesFromPaths(cmd.Printf, fileNames...)
+	if err != nil {
+		return cli.MessageAndError("Error reading resources", err)
+	}
+
+	// Step 2: sort objects by type
+	var profiles []*minderv1.Profile
+	var ruleTypes []*minderv1.RuleType
+	var dataSources []*minderv1.DataSource
+
+	// Explicitly set the project for each resource
+	project := viper.GetString("project")
+	v1Context := &minderv1.Context{
+		Project: &project,
+	}
+	v2Context := &minderv1.ContextV2{
+		ProjectId: project,
+	}
+
+	for _, obj := range objects {
+		switch rsrc := obj.(type) {
+		case *minderv1.Profile:
+			rsrc.Context = v1Context
+			profiles = append(profiles, rsrc)
+		case *minderv1.RuleType:
+			rsrc.Context = v1Context
+			ruleTypes = append(ruleTypes, rsrc)
+		case *minderv1.DataSource:
+			rsrc.Context = v2Context
+			dataSources = append(dataSources, rsrc)
+		default:
+			return fmt.Errorf("unsupported object type: %T", obj)
+		}
+	}
+
+	// Step 3: apply objects, starting with DataSources
+	dataSourceClient := minderv1.NewDataSourceServiceClient(conn)
+	for _, dataSource := range dataSources {
+		if err := api.UpsertDataSource(ctx, dataSourceClient, dataSource); err != nil {
+			return cli.MessageAndError(fmt.Sprintf("Unable to create datasource %s", dataSource.Name), err)
+		}
+	}
+
+	ruleTypeClient := minderv1.NewRuleTypeServiceClient(conn)
+	for _, ruleType := range ruleTypes {
+		if err := api.UpsertRuleType(ctx, ruleTypeClient, ruleType); err != nil {
+			return cli.MessageAndError(fmt.Sprintf("Unable to create ruletype %s", ruleType.Name), err)
+		}
+	}
+
+	profileClient := minderv1.NewProfileServiceClient(conn)
+	for _, profile := range profiles {
+		if err := api.UpsertProfile(ctx, profileClient, profile); err != nil {
+			return cli.MessageAndError(fmt.Sprintf("Unable to create profile %s", profile.Name), err)
+		}
+	}
+
+	return nil
+}
+
+func init() {
+	RootCmd.AddCommand(applyCmd)
+	// Flags
+	applyCmd.Flags().StringSliceP("file", "f", []string{}, "Input file or directory")
+}

--- a/cmd/cli/app/profile/export.go
+++ b/cmd/cli/app/profile/export.go
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: Copyright 2023 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package profile
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"google.golang.org/grpc"
+	"gopkg.in/yaml.v3"
+
+	"github.com/mindersec/minder/internal/util/cli"
+	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
+	"github.com/mindersec/minder/pkg/fileconvert"
+)
+
+var exportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Export profile and associated resources",
+	Long:  `The profile export subcommand lets you retrieve the definition of a profile and its associated resources.`,
+	RunE:  cli.GRPCClientWrapRunE(exportCommand),
+}
+
+// getCommand is the profile "get" subcommand
+func exportCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grpc.ClientConn) error {
+	output, closer, err := getOutput(cmd)
+	if err != nil {
+		return cli.MessageAndError("Error opening output", err)
+	}
+	defer closer()
+
+	profileClient := minderv1.NewProfileServiceClient(conn)
+
+	project := viper.GetString("project")
+	id := viper.GetString("id")
+	name := viper.GetString("name")
+
+	if id == "" && name == "" {
+		return cli.MessageAndError("Error getting profile", fmt.Errorf("id or name required"))
+	}
+
+	// No longer print usage on returned error, since we've parsed our inputs
+	// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
+	cmd.SilenceUsage = true
+
+	prof, err := getProfileByNameOrId(ctx, profileClient, project, id, name)
+	if err != nil {
+		return cli.MessageAndError("Error getting profile", err)
+	}
+	if err := fileconvert.WriteResource(output, prof); err != nil {
+		return cli.MessageAndError("Error encoding profile", err)
+	}
+
+	// Fetch associated resources
+	rulesClient := minderv1.NewRuleTypeServiceClient(conn)
+
+	// TODO: it would be nice if this were just a list of rules...
+	rules := slices.Concat(
+		prof.GetRepository(),
+		prof.GetBuildEnvironment(),
+		prof.GetArtifact(),
+		prof.GetPullRequest(),
+		prof.GetRelease(),
+		prof.GetPipelineRun(),
+		prof.GetTaskRun(),
+		prof.GetBuild(),
+	)
+	ruletypes := make([]string, 0, len(rules))
+	for _, res := range rules {
+		ruletypes = append(ruletypes, res.GetType())
+	}
+	slices.Sort(ruletypes)
+	ruletypes = slices.Compact(ruletypes)
+
+	// Collect the referenced datasources from the rule types as we process them.
+	datasources := make([]string, 0)
+	for _, ruletype := range ruletypes {
+		resp, err := rulesClient.GetRuleTypeByName(ctx, &minderv1.GetRuleTypeByNameRequest{
+			Context: &minderv1.Context{Project: &project},
+			Name:    ruletype,
+		})
+		if err != nil {
+			return cli.MessageAndError(fmt.Sprintf("Error getting rule type %q", ruletype), err)
+		}
+		ruletype := resp.GetRuleType()
+		for _, datasource := range ruletype.GetDef().GetEval().GetDataSources() {
+			datasources = append(datasources, datasource.GetName())
+		}
+		if err := fileconvert.WriteResource(output, ruletype); err != nil {
+			return cli.MessageAndError(fmt.Sprintf("Error encoding rule type %q", ruletype.GetName()), err)
+		}
+	}
+
+	// Remove duplicates from the datasource list
+	slices.Sort(datasources)
+	datasources = slices.Compact(datasources)
+	datasourceClient := minderv1.NewDataSourceServiceClient(conn)
+	for _, datasource := range datasources {
+		resp, err := datasourceClient.GetDataSourceByName(ctx, &minderv1.GetDataSourceByNameRequest{
+			Context: &minderv1.ContextV2{ProjectId: project},
+			Name:    datasource,
+		})
+		if err != nil {
+			return cli.MessageAndError(fmt.Sprintf("Error getting datasource %q", datasource), err)
+		}
+		if err := fileconvert.WriteResource(output, resp.GetDataSource()); err != nil {
+			return cli.MessageAndError(fmt.Sprintf("Error encoding datasource %q", datasource), err)
+		}
+	}
+
+	return nil
+}
+
+func getOutput(cmd *cobra.Command) (*yaml.Encoder, func(), error) {
+	outputFlag := viper.GetString("output")
+
+	var outFile io.Writer
+	closer := func() {}
+
+	if outputFlag == "" || outputFlag == "-" {
+		outFile = cmd.OutOrStdout()
+	} else {
+		file, err := os.Create(filepath.Clean(outputFlag))
+		if err != nil {
+			return nil, closer, cli.MessageAndError("Error opening file", err)
+		}
+		outFile = file
+		closer = func() {
+			_ = file.Close()
+		}
+	}
+	output := yaml.NewEncoder(outFile)
+	yamlClose := func() {
+		_ = output.Close()
+		closer()
+	}
+
+	return output, yamlClose, nil
+}
+
+func getProfileByNameOrId(
+	ctx context.Context, client minderv1.ProfileServiceClient, project string, id string, name string,
+) (*minderv1.Profile, error) {
+	if id != "" {
+		p, err := client.GetProfileById(ctx, &minderv1.GetProfileByIdRequest{
+			Context: &minderv1.Context{Project: &project},
+			Id:      id,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return p.GetProfile(), nil
+	}
+	p, err := client.GetProfileByName(ctx, &minderv1.GetProfileByNameRequest{
+		Context: &minderv1.Context{Project: &project},
+		Name:    name,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return p.GetProfile(), nil
+}
+
+func init() {
+	ProfileCmd.AddCommand(exportCmd)
+	// Flags
+	exportCmd.Flags().StringP("id", "i", "", "ID for the profile to query")
+	exportCmd.Flags().StringP("name", "n", "", "Name for the profile to query")
+	exportCmd.Flags().StringP("output", "o", "-", "Output file (or stdout)")
+	exportCmd.MarkFlagsMutuallyExclusive("id", "name")
+}

--- a/pkg/api/apply.go
+++ b/pkg/api/apply.go
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright 2025 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package api provides utility functions for working with the Minder APIs.
+// Currently, this provides "upsert" methods for a few API calls that support
+// Create and Update methods -- Upsert attempts a create, and falls back to
+// update if the create fails with AlreadyExists.
+package api
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+// We could try to do this with generics, but there are a lot of distinct types and names,
+// and I think we'd end up being sad.  Instead, we repeat the same code three times.
+
+// UpsertProfile creates or updates a profile using the supplied client.
+func UpsertProfile(
+	ctx context.Context, client minderv1.ProfileServiceClient, profile *minderv1.Profile,
+) error {
+	_, err := client.CreateProfile(ctx, &minderv1.CreateProfileRequest{
+		Profile: profile,
+	})
+	if err == nil {
+		return nil
+	}
+	rpcStatus, _ := status.FromError(err)
+	if rpcStatus.Code() == codes.AlreadyExists {
+		_, err = client.UpdateProfile(ctx, &minderv1.UpdateProfileRequest{
+			Profile: profile,
+		})
+	}
+	return err
+}
+
+// UpsertRuleType creates or updates a ruleType using the supplied client.
+func UpsertRuleType(
+	ctx context.Context, client minderv1.RuleTypeServiceClient, ruleType *minderv1.RuleType,
+) error {
+	_, err := client.CreateRuleType(ctx, &minderv1.CreateRuleTypeRequest{
+		RuleType: ruleType,
+	})
+	if err == nil {
+		return nil
+	}
+	// If not a grpc error, this will become grpc.Unknown with the original error message
+	rpcStatus, _ := status.FromError(err)
+	if rpcStatus.Code() == codes.AlreadyExists {
+		_, err = client.UpdateRuleType(ctx, &minderv1.UpdateRuleTypeRequest{
+			RuleType: ruleType,
+		})
+	}
+	return err
+}
+
+// UpsertDataSource creates or updates a dataSource using the supplied client.
+func UpsertDataSource(
+	ctx context.Context, client minderv1.DataSourceServiceClient, dataSource *minderv1.DataSource,
+) error {
+	_, err := client.CreateDataSource(ctx, &minderv1.CreateDataSourceRequest{
+		DataSource: dataSource,
+	})
+	if err == nil {
+		return nil
+	}
+	// If not a grpc error, this will become grpc.Unknown with the original error message
+	rpcStatus, _ := status.FromError(err)
+	if rpcStatus.Code() == codes.AlreadyExists {
+		_, err = client.UpdateDataSource(ctx, &minderv1.UpdateDataSourceRequest{
+			DataSource: dataSource,
+		})
+	}
+	return err
+}

--- a/pkg/fileconvert/collect.go
+++ b/pkg/fileconvert/collect.go
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright 2023 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package fileconvert provides functions for marshalling Minder proto objects
+// to and from on-disk formats like YAML.
+package fileconvert
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/mindersec/minder/internal/util"
+	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+// Printer provides an interface for passing a printf-like function.
+type Printer func(string, ...any)
+
+// ResourcesFromPaths collects
+func ResourcesFromPaths(printer Printer, paths ...string) ([]minderv1.ResourceMeta, error) {
+	files, err := util.ExpandFileArgs(paths...)
+	if err != nil {
+		return nil, fmt.Errorf("Error expanding args: %w", err)
+	}
+
+	objects := make([]minderv1.ResourceMeta, 0, len(files))
+	for _, file := range files {
+		var input Decoder
+		if file.Path == "-" {
+			input = yaml.NewDecoder(os.Stdin)
+		} else {
+			var closer io.Closer
+			input, closer = DecoderForFile(file.Path)
+			if input == nil {
+				// Not a valid file type, skip it.
+				continue
+			}
+			defer closer.Close()
+		}
+
+		for i := 0; ; i = i + 1 {
+			resource, err := ReadResource(input)
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				if file.Expanded && i == 0 {
+					// Skip files expanded from directories where the contents aren't valid
+					printer("Skipping expanded file %s", file.Path)
+					break
+				}
+				return nil, fmt.Errorf("error reading resource from file %s: %w", file.Path, err)
+			}
+			objects = append(objects, resource)
+		}
+	}
+	return objects, nil
+}

--- a/pkg/fileconvert/encodedecode.go
+++ b/pkg/fileconvert/encodedecode.go
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: Copyright 2023 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package fileconvert provides functions for marshalling Minder proto objects
+// to and from on-disk formats like YAML.
+package fileconvert
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"gopkg.in/yaml.v3"
+
+	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+// Encoder is a superset of the yaml.Encoder and json.Encoder interfaces.
+type Encoder interface {
+	Encode(v any) error
+}
+
+// Decoder is a superset of the yaml.Decoder and json.Decoder interfaces.
+type Decoder interface {
+	Decode(v any) error
+}
+
+var _ Decoder = (*yaml.Decoder)(nil)
+var _ Decoder = (*json.Decoder)(nil)
+
+// DecoderForFile returns a Decoder for the file at the specified path,
+// or nil if the file is not of the appropriate type.
+func DecoderForFile(path string) (Decoder, io.Closer) {
+	path = filepath.Clean(path)
+	ext := filepath.Ext(path)
+	var builder func(io.Reader) Decoder
+	// we return functions here so that we can early-exit without opening the file if the extension is unmatched.
+	switch ext {
+	case ".json":
+		builder = func(r io.Reader) Decoder { return json.NewDecoder(r) }
+	case ".yaml", ".yml":
+		builder = func(r io.Reader) Decoder { return yaml.NewDecoder(r) }
+	default:
+		return nil, nil
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, nil
+	}
+	return builder(file), file
+}
+
+// WriteResource outputs a Minder proto resource to an existing Encoder.
+// Only known resource types are supported; others will return an error.
+//
+// This uses the proto JSON serialization to convert the resource to an
+// object, as a naive transformation from proto to YAML does not nicely
+// deal with Structs and other proto features.  In the case of JSON, this
+// *does* mean that we encode to JSON twice, but this is not expected to
+// be a high-performance path.
+func WriteResource(output Encoder, resource minderv1.ResourceMeta) error {
+	var jsonData []byte
+	var err error
+	switch r := resource.(type) {
+	case *minderv1.Profile:
+		r.Type = string(minderv1.ProfileResource)
+		r.Version = "v1"
+	case *minderv1.RuleType:
+		r.Type = string(minderv1.RuleTypeResource)
+		r.Version = "v1"
+		// RuleTypes have customized enum fields (used only during file/IO).
+		// Preserve this behavior (at least for now).
+		jsonData, err = json.Marshal(r)
+	case *minderv1.DataSource:
+		r.Type = string(minderv1.DataSourceResource)
+		r.Version = "v1"
+	default:
+		return fmt.Errorf("unknown resource type: %T", resource)
+	}
+	if jsonData == nil {
+		marshaller := protojson.MarshalOptions{UseProtoNames: true}
+		jsonData, err = marshaller.Marshal(resource)
+	}
+	if err != nil {
+		return fmt.Errorf("error marshaling JSON: %w", err)
+	}
+	var genericObject any
+
+	if err = json.Unmarshal(jsonData, &genericObject); err != nil {
+		return fmt.Errorf("error unmarshaling JSON: %w", err)
+	}
+
+	return output.Encode(genericObject)
+}
+
+// ReadResource reads a single resource from the specified Decoder.
+// Only known resource types are supported; others will return an error.
+// Given that multiple resources can be stored in a single file, the
+// the input may not be fully consumed.
+//
+// The resource is returned as a proto.Message, which can be type-asserted
+// to the appropriate type (see also ReadResourceTyped).  Like
+// WriteResource, this uses proto JSON serialization in addition to naive
+// decoding to handle proto-specific encoding features.
+func ReadResource(input Decoder) (minderv1.ResourceMeta, error) {
+	// All our types are JSON object
+	var genericObject map[string]any
+	if err := input.Decode(&genericObject); err != nil {
+		return nil, fmt.Errorf("error decoding: %w", err)
+	}
+	objectType, ok := genericObject["type"].(string)
+	if !ok {
+		return nil, fmt.Errorf("resource type not found")
+	}
+	objectVersion, ok := genericObject["version"].(string)
+	if !ok || objectVersion != "v1" {
+		return nil, fmt.Errorf("unsupported resource version: %s", objectVersion)
+	}
+	jsonData, err := json.Marshal(genericObject)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling JSON: %w", err)
+	}
+	switch objectType {
+	case string(minderv1.ProfileResource):
+		var profile minderv1.Profile
+		if err := json.Unmarshal(jsonData, &profile); err != nil {
+			return nil, fmt.Errorf("error unmarshaling profile: %w", err)
+		}
+		if err := profile.Validate(); err != nil {
+			return nil, err
+		}
+		return &profile, nil
+	case string(minderv1.RuleTypeResource):
+		var ruleType minderv1.RuleType
+		// RuleTypes have customized enum fields (used only for storage).
+		// Preserve this behavior (at least for now).
+		if err := json.Unmarshal(jsonData, &ruleType); err != nil {
+			return nil, fmt.Errorf("error unmarshaling rule type: %w", err)
+		}
+		if err := ruleType.Validate(); err != nil {
+			return nil, err
+		}
+		return &ruleType, nil
+	case string(minderv1.DataSourceResource):
+		var dataSource minderv1.DataSource
+		if err := protojson.Unmarshal(jsonData, &dataSource); err != nil {
+			return nil, fmt.Errorf("error unmarshaling data source: %w", err)
+		}
+		if err := dataSource.Validate(); err != nil {
+			return nil, err
+		}
+		return &dataSource, nil
+	default:
+		return nil, fmt.Errorf("unknown resource type: %s", objectType)
+	}
+}
+
+// ReadResourceTyped reads a single resource from the specified Decoder and
+// returns it as the specified subtype of proto.Messsage.  This is a convenience
+// wrapper around ReadResource that handles the type assertion for you.
+func ReadResourceTyped[T proto.Message](input Decoder) (T, error) {
+	var zero T
+	r, err := ReadResource(input)
+	if err != nil {
+		return zero, err
+	}
+	typed, ok := r.(T)
+	if !ok {
+		return zero, fmt.Errorf("unexpected resource type: %T", r)
+	}
+	return typed, nil
+}

--- a/pkg/fileconvert/fileconvert_test.go
+++ b/pkg/fileconvert/fileconvert_test.go
@@ -1,0 +1,256 @@
+// SPDX-FileCopyrightText: Copyright 2023 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package fileconvert
+
+import (
+	"bytes"
+	"cmp"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	gocmp "github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/structpb"
+	"gopkg.in/yaml.v3"
+
+	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+func TestReadResource(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   string
+		want    proto.Message
+		wantErr bool
+	}{
+		{
+			name: "valid profile",
+			input: `
+type: profile
+version: v1
+name: test-profile
+repository:
+  - type: sample-rule
+    def: {}
+`,
+			want: &minderv1.Profile{
+				Type:    string(minderv1.ProfileResource),
+				Version: "v1",
+				Name:    "test-profile",
+				Repository: []*minderv1.Profile_Rule{
+					{
+						Type: "sample-rule",
+						Def:  &structpb.Struct{},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid rule type",
+			input: `
+type: rule-type
+version: v1
+name: test-rule-type
+def:
+  in_entity: "artifact"
+  rule_schema: {}
+  ingest:
+    type: fake
+  eval:
+    type: other
+`,
+			want: &minderv1.RuleType{
+				Type:    string(minderv1.RuleTypeResource),
+				Version: "v1",
+				Name:    "test-rule-type",
+				Def: &minderv1.RuleType_Definition{
+					InEntity:   "artifact",
+					RuleSchema: &structpb.Struct{},
+					Ingest: &minderv1.RuleType_Definition_Ingest{
+						Type: "fake",
+					},
+					Eval: &minderv1.RuleType_Definition_Eval{
+						Type: "other",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid data source",
+			input: `
+type: data-source
+version: v1
+name: test-data-source
+rest:
+  def:
+    function:
+      endpoint: http://example.com/
+      input_schema: {}
+`,
+			want: &minderv1.DataSource{
+				Type:    string(minderv1.DataSourceResource),
+				Version: "v1",
+				Name:    "test-data-source",
+				Driver: &minderv1.DataSource_Rest{
+					Rest: &minderv1.RestDataSource{
+						Def: map[string]*minderv1.RestDataSource_Def{
+							"function": {
+								Endpoint:    "http://example.com/",
+								InputSchema: &structpb.Struct{},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "rule type validate fails",
+			input: `
+type: rule-type
+version: v1
+name: test-rule-type
+# def is required
+`,
+			wantErr: true,
+		},
+		{
+			name: "invalid version",
+			input: `
+type: profile
+version: v2
+`,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "missing type",
+			input: `
+version: v1
+`,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "unknown resource type",
+			input: `
+type: unknown
+version: v1
+`,
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			decoder := yaml.NewDecoder(bytes.NewBufferString(tt.input))
+			got, err := ReadResource(decoder)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if diff := gocmp.Diff(got, tt.want, protocmp.Transform()); diff != "" {
+				t.Errorf("ReadResource on \n%s\n\n%s", tt.input, diff)
+			}
+		})
+	}
+}
+
+func TestReadResourceTyped(t *testing.T) {
+	t.Parallel()
+
+	profileDecoder, profileCloser := DecoderForFile("testdata/directory/profile.json")
+	require.NotNil(t, profileDecoder, "Expected non-nil decoder for profile")
+	t.Cleanup(func() { _ = profileCloser.Close() })
+	_, err := ReadResourceTyped[*minderv1.Profile](profileDecoder)
+	require.NoError(t, err, "Expected no error reading profile")
+
+	dataSourceDecoder, dataSourceCloser := DecoderForFile("testdata/directory/datasource.yaml")
+	require.NotNil(t, dataSourceDecoder, "Expected non-nil decoder for profile")
+	t.Cleanup(func() { _ = dataSourceCloser.Close() })
+	_, err = ReadResourceTyped[*minderv1.DataSource](dataSourceDecoder)
+	require.NoError(t, err, "Expected no error reading profile")
+
+	ruleTypeDecoder, ruleTypeCloser := DecoderForFile("testdata/directory/ruletype.yaml")
+	require.NotNil(t, ruleTypeDecoder, "Expected non-nil decoder for profile")
+	t.Cleanup(func() { _ = ruleTypeCloser.Close() })
+	_, err = ReadResourceTyped[*minderv1.RuleType](ruleTypeDecoder)
+	require.NoError(t, err, "Expected no error reading profile")
+}
+
+func TestReadAll(t *testing.T) {
+	t.Parallel()
+
+	dirResources, err := ResourcesFromPaths(t.Logf, "testdata/directory")
+	require.NoError(t, err)
+
+	collectedInput, closer := DecoderForFile("testdata/resources.yaml")
+	require.NotNil(t, collectedInput, "Expected non-nil decoder for profile")
+	t.Cleanup(func() { _ = closer.Close() })
+	collected := make([]proto.Message, 0, 3)
+	for {
+		resource, err := ReadResource(collectedInput)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		collected = append(collected, resource)
+	}
+
+	assert.Equal(t, len(collected), len(dirResources))
+	for i, dirResource := range dirResources {
+		diff := gocmp.Diff(dirResource, collected[i], protocmp.Transform())
+		if diff != "" {
+			t.Errorf("Read resources did not match expected (-dir,+file):\n%s", diff)
+		}
+	}
+}
+
+func TestReadWriteRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	dirResources, err := ResourcesFromPaths(t.Logf, "testdata/directory")
+	require.NoError(t, err)
+
+	tempFile := filepath.Clean(filepath.Join(t.TempDir(), "collected.yaml"))
+	outFile, err := os.Create(tempFile)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = outFile.Close() })
+
+	slices.SortFunc(dirResources, func(a, b minderv1.ResourceMeta) int {
+		return cmp.Or(
+			strings.Compare(a.GetType(), b.GetType()),
+			strings.Compare(a.GetName(), b.GetName()),
+		)
+	})
+
+	encoder := yaml.NewEncoder(outFile)
+	encoder.SetIndent(2)
+	for _, resource := range dirResources {
+		err = WriteResource(encoder, resource)
+		require.NoError(t, err)
+	}
+
+	expectedContents, err := os.ReadFile("testdata/resources.yaml")
+	require.NoError(t, err)
+	gotContents, err := os.ReadFile(tempFile)
+	require.NoError(t, err)
+	if diff := gocmp.Diff(string(expectedContents), string(gotContents)); diff != "" {
+		t.Errorf("Read resources did not match expected (-want,+got):\n%s", diff)
+	}
+}

--- a/pkg/fileconvert/testdata/directory/datasource.yaml
+++ b/pkg/fileconvert/testdata/directory/datasource.yaml
@@ -1,0 +1,16 @@
+---
+version: v1
+type: data-source
+name: test-data
+rest:
+  def:
+    lookup:
+      endpoint: 'https://www.bestpractices.dev/projects/{id}.json'
+      parse: json
+      input_schema:
+        required:
+          - id
+        properties:
+          id:
+            type: string
+            description: The project ID to lookup

--- a/pkg/fileconvert/testdata/directory/other.test.yaml
+++ b/pkg/fileconvert/testdata/directory/other.test.yaml
@@ -1,0 +1,13 @@
+# This is valid yaml for a test, but isn't a valid resource.
+tests:
+  - name: "Should pass"
+    def: {}
+    params: {}
+    expect: "pass"
+    entity: test-repo
+      type: repository
+      entity:
+        owner: "coolhead"
+        name: "haze-wave"
+    git:
+      repo_base: action_enabled

--- a/pkg/fileconvert/testdata/directory/profile.ignored
+++ b/pkg/fileconvert/testdata/directory/profile.ignored
@@ -1,0 +1,18 @@
+# This profile is valid YAML, but since it doesn't have the correct extension,
+# it is ignored.
+---
+type: profile
+version: v1
+name: repo-security
+display_name: Repository Security
+context:
+  provider: github
+alert: "off"
+remediate: "off"
+repository:
+  - type: secret_scanning
+    def: {}
+  - type: codeql_enabled
+    def:
+      languages: [go, javascript, typescript]
+      schedule_interval: '30 4 * * 0'

--- a/pkg/fileconvert/testdata/directory/profile.json
+++ b/pkg/fileconvert/testdata/directory/profile.json
@@ -1,0 +1,24 @@
+{
+  "type": "profile",
+  "version": "v1",
+  "name": "repo-security",
+  "display_name": "Repository Security",
+  "context": {
+    "provider": "github"
+  },
+  "alert": "off",
+  "remediate": "off",
+  "repository": [
+    {
+      "type": "secret_scanning",
+      "def": {}
+    },
+    {
+      "type": "codeql_enabled",
+      "def": {
+        "languages": ["go", "javascript", "typescript"],
+        "schedule_interval": "30 4 * * 0"
+      }
+    }
+  ]
+}

--- a/pkg/fileconvert/testdata/directory/ruletype.yaml
+++ b/pkg/fileconvert/testdata/directory/ruletype.yaml
@@ -1,0 +1,41 @@
+type: rule-type
+version: v1
+name: source_code_is_public
+display_name: The project's source code is publicly readable
+release_phase: alpha
+context:
+  provider: github
+severity:
+  value: info
+short_failure_message: The project's source code is not publicly readable.
+description: |
+  Enable users to access and review the project’s source code and
+  history, promoting transparency and collaboration within the project
+  community.
+guidance: |
+  Change repository visibility via the
+  [Settings](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/setting-repository-visibility#changing-a-repositorys-visibility)
+  page on GitHub.
+def:
+  in_entity: repository
+  ingest:
+    type: git
+  rule_schema: {}
+  eval:
+    type: rego
+    data_sources:
+      - name: ghapi
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+
+        import rego.v1
+
+        default allow := false
+
+        allow if {
+          # This rule checks whether the repository is private using
+          # info tied to the entity itself.
+          not input.properties["is_private"]
+        }

--- a/pkg/fileconvert/testdata/resources.yaml
+++ b/pkg/fileconvert/testdata/resources.yaml
@@ -1,0 +1,76 @@
+name: test-data
+rest:
+  def:
+    lookup:
+      endpoint: https://www.bestpractices.dev/projects/{id}.json
+      input_schema:
+        properties:
+          id:
+            description: The project ID to lookup
+            type: string
+        required:
+          - id
+      parse: json
+type: data-source
+version: v1
+---
+alert: "off"
+context:
+  provider: github
+display_name: Repository Security
+name: repo-security
+remediate: "off"
+repository:
+  - def: {}
+    type: secret_scanning
+  - def:
+      languages:
+        - go
+        - javascript
+        - typescript
+      schedule_interval: 30 4 * * 0
+    type: codeql_enabled
+type: profile
+version: v1
+---
+context:
+  provider: github
+def:
+  eval:
+    data_sources:
+      - name: ghapi
+    rego:
+      def: |
+        package minder
+
+        import rego.v1
+
+        default allow := false
+
+        allow if {
+          # This rule checks whether the repository is private using
+          # info tied to the entity itself.
+          not input.properties["is_private"]
+        }
+      type: deny-by-default
+    type: rego
+  in_entity: repository
+  ingest:
+    type: git
+  rule_schema: {}
+description: |
+  Enable users to access and review the project’s source code and
+  history, promoting transparency and collaboration within the project
+  community.
+display_name: The project's source code is publicly readable
+guidance: |
+  Change repository visibility via the
+  [Settings](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/setting-repository-visibility#changing-a-repositorys-visibility)
+  page on GitHub.
+name: source_code_is_public
+release_phase: alpha
+severity:
+  value: info
+short_failure_message: The project's source code is not publicly readable.
+type: rule-type
+version: v1


### PR DESCRIPTION
# Summary

Adds a command to export a profile along with all dependencies for that profile (ruletypes and datasources).

Adds a command to bulk-import resources from either a file (such as the one from `profile export`), or a directory of files.

This should simplify migrating from one Minder server to another, or applying resources from an IaC repository.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Added unit tests for the file import/export (and found some fun edge cases / bugs).  Also tested import/export cycle with the OpenSSF baseline between Stacklok's public service and a local Minder instance.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
