### PR TITLE
Support different credential files for different API hosts

### DIFF
--- a/cmd/cli/app/auth/auth_delete.go
+++ b/cmd/cli/app/auth/auth_delete.go
@@ -37,7 +37,7 @@ func deleteCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *gr
 	}
 
 	// We read name and email from the JWT.  We don't need to validate it here.
-	creds, err := cli.LoadCredentials()
+	creds, err := cli.LoadCredentials(conn.CanonicalTarget())
 	if err != nil {
 		return cli.MessageAndError("Error loading credentials from file", err)
 	}
@@ -77,7 +77,7 @@ func deleteCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *gr
 
 	// This step is added to avoid confusing the users by seeing their credentials locally, however it is not
 	// directly related to user deletion because the token will expire after 5 minutes and cannot be refreshed
-	err = cli.RemoveCredentials()
+	err = cli.RemoveCredentials(conn.CanonicalTarget())
 	if err != nil {
 		cmd.Println(cli.WarningBanner.Render("Failed to remove locally stored credentials."))
 	}

--- a/cmd/cli/app/auth/auth_login.go
+++ b/cmd/cli/app/auth/auth_login.go
@@ -21,7 +21,7 @@ var loginCmd = &cobra.Command{
 	Use:   "login",
 	Short: "Login to Minder",
 	Long: `The login command allows for logging in to Minder. Upon successful login, credentials will be saved to
-$XDG_CONFIG_HOME/minder/credentials.json`,
+$XDG_CONFIG_HOME/minder/ based on the hostname and port of the server.`,
 	RunE: cli.GRPCClientWrapRunE(LoginCommand),
 }
 

--- a/cmd/cli/app/auth/auth_logout.go
+++ b/cmd/cli/app/auth/auth_logout.go
@@ -18,16 +18,19 @@ import (
 var logoutCmd = &cobra.Command{
 	Use:   "logout",
 	Short: "Logout from minder control plane.",
-	Long:  `Logout from minder control plane. Credentials will be removed from $XDG_CONFIG_HOME/minder/credentials.json`,
+	Long:  `Logout from minder control plane. Credentials will be removed from $XDG_CONFIG_HOME/minder/`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		if err := cli.RemoveCredentials(); err != nil {
-			return cli.MessageAndError("Error removing credentials", err)
-		}
-
 		clientConfig, err := config.ReadConfigFromViper[clientconfig.Config](viper.GetViper())
 		if err != nil {
 			return cli.MessageAndError("Unable to read config", err)
 		}
+		if err := cli.RemoveCredentials(clientConfig.GRPCClientConfig.GetGRPCAddress()); err != nil {
+			return cli.MessageAndError("Error removing credentials", err)
+		}
+		// No longer print usage on returned error, since we've parsed our inputs
+		// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
+		cmd.SilenceUsage = true
+
 		issuerUrlStr := clientConfig.Identity.CLI.IssuerUrl
 
 		parsedURL, err := url.Parse(issuerUrlStr)
@@ -35,11 +38,9 @@ var logoutCmd = &cobra.Command{
 			return cli.MessageAndError("Error parsing issuer URL", err)
 		}
 
-		// No longer print usage on returned error, since we've parsed our inputs
-		// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
-		cmd.SilenceUsage = true
-
-		// TODO: we should probably get this from the server in a header in the future.
+		// TODO: use zitadel/oidc/v3/pkg/client/rp's EndSession alongside calling the grpc
+		// endpoint for WWW-Authenticate or use the JWT realm to determine the rp URL
+		// https://pkg.go.dev/github.com/zitadel/oidc/v3@v3.34.1/pkg/client/rp#EndSession
 		logoutUrl := parsedURL.JoinPath("realms", clientConfig.Identity.CLI.Realm, "/protocol/openid-connect/logout")
 		cmd.Println(cli.SuccessBanner.Render("You have successfully logged out of the CLI."))
 		cmd.Printf("If you would like to log out of the browser, you can visit %s\n", logoutUrl.String())

--- a/cmd/cli/app/auth/offline_token/offline_use.go
+++ b/cmd/cli/app/auth/offline_token/offline_use.go
@@ -75,13 +75,13 @@ func offlineUseCommand(_ context.Context, cmd *cobra.Command, _ []string, _ *grp
 	}
 	realmUrl = parsedUrl.JoinPath("protocol/openid-connect/token").String()
 
-	creds, err := cli.RefreshCredentials(tok, realmUrl, clientID)
+	creds, err := cli.RefreshCredentials(grpcCfg.GetGRPCAddress(), tok, realmUrl, clientID)
 	if err != nil {
 		return fmt.Errorf("couldn't fetch credentials: %v", err)
 	}
 
 	// save credentials
-	filePath, err := cli.SaveCredentials(cli.OpenIdCredentials{
+	filePath, err := cli.SaveCredentials(grpcCfg.GetGRPCAddress(), cli.OpenIdCredentials{
 		AccessToken:          creds.AccessToken,
 		RefreshToken:         creds.RefreshToken,
 		AccessTokenExpiresAt: creds.AccessTokenExpiresAt,

--- a/cmd/cli/app/root.go
+++ b/cmd/cli/app/root.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/mindersec/minder/internal/constants"
 	"github.com/mindersec/minder/internal/util/cli"
 	"github.com/mindersec/minder/pkg/config"
 	clientconfig "github.com/mindersec/minder/pkg/config/client"
@@ -30,7 +29,7 @@ https://docs.stacklok.com/minder`,
 			// Print a warning if the build is not pointing to the production environment
 			cfg, _ := config.ReadConfigFromViper[clientconfig.Config](viper.GetViper())
 
-			if cfg == nil || cfg.GRPCClientConfig.Host != constants.MinderGRPCHost {
+			if cfg == nil || cfg.GRPCClientConfig.Host == "localhost" {
 				fmt.Fprintf(
 					cmd.ErrOrStderr(),
 					"WARNING: Running against a test environment (%s) and may not be stable\n",

--- a/internal/util/cli/credentials.go
+++ b/internal/util/cli/credentials.go
@@ -136,18 +136,6 @@ func SaveCredentials(serverAddress string, tokens OpenIdCredentials) (string, er
 
 // RemoveCredentials removes the local credentials file
 func RemoveCredentials(serverAddress string) error {
-	// remove credentials file
-	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
-
-	// just delete token from credentials file
-	if xdgConfigHome == "" {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return fmt.Errorf("error getting home directory: %v", err)
-		}
-		xdgConfigHome = filepath.Join(homeDir, ".config")
-	}
-
 	filePath, err := getCredentialsPath(serverAddress, false)
 	if err != nil {
 		return fmt.Errorf("error getting credentials path: %v", err)

--- a/internal/util/cli/credentials.go
+++ b/internal/util/cli/credentials.go
@@ -39,12 +39,23 @@ type OpenIdCredentials struct {
 	AccessTokenExpiresAt time.Time `json:"expiry"`
 }
 
-func getCredentialsPath() (string, error) {
+func getCredentialsPath(serverAddress string, create bool) (string, error) {
 	cfgPath, err := GetConfigDirPath()
 	if err != nil {
 		return "", fmt.Errorf("error getting config path: %v", err)
 	}
 
+	// Prefer the server address if presentAn
+	preferredFile := filepath.Join(cfgPath, strings.ReplaceAll(serverAddress, ":", "_")+".json")
+	if create {
+		return preferredFile, nil
+	}
+	fi, err := os.Stat(preferredFile)
+	if err == nil && fi.Mode().IsRegular() {
+		return preferredFile, nil
+	}
+
+	// Legacy path -- read non-server-specific credentials if no server-specific file exists
 	filePath := filepath.Join(cfgPath, "credentials.json")
 	return filePath, nil
 }
@@ -98,14 +109,14 @@ func GetGrpcConnection(
 }
 
 // SaveCredentials saves the credentials to a file
-func SaveCredentials(tokens OpenIdCredentials) (string, error) {
+func SaveCredentials(serverAddress string, tokens OpenIdCredentials) (string, error) {
 	// marshal the credentials to json
 	credsJSON, err := json.Marshal(tokens)
 	if err != nil {
 		return "", fmt.Errorf("error marshaling credentials: %v", err)
 	}
 
-	filePath, err := getCredentialsPath()
+	filePath, err := getCredentialsPath(serverAddress, true)
 	if err != nil {
 		return "", fmt.Errorf("error getting credentials path: %v", err)
 	}
@@ -124,7 +135,7 @@ func SaveCredentials(tokens OpenIdCredentials) (string, error) {
 }
 
 // RemoveCredentials removes the local credentials file
-func RemoveCredentials() error {
+func RemoveCredentials(serverAddress string) error {
 	// remove credentials file
 	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
 
@@ -137,8 +148,12 @@ func RemoveCredentials() error {
 		xdgConfigHome = filepath.Join(homeDir, ".config")
 	}
 
-	filePath := filepath.Join(xdgConfigHome, "minder", "credentials.json")
-	err := os.Remove(filePath)
+	filePath, err := getCredentialsPath(serverAddress, false)
+	if err != nil {
+		return fmt.Errorf("error getting credentials path: %v", err)
+	}
+
+	err = os.Remove(filePath)
 	if err != nil {
 		return fmt.Errorf("error removing credentials file: %v", err)
 	}
@@ -148,7 +163,7 @@ func RemoveCredentials() error {
 // GetToken retrieves the access token from the credentials file and refreshes it if necessary
 func GetToken(serverAddress string, opts []grpc.DialOption, issuerUrl string, realm string, clientId string) (string, error) {
 	refreshLimit := 10 * time.Second
-	creds, err := LoadCredentials()
+	creds, err := LoadCredentials(serverAddress)
 	if err != nil {
 		return "", fmt.Errorf("error loading credentials: %v", err)
 	}
@@ -165,7 +180,7 @@ func GetToken(serverAddress string, opts []grpc.DialOption, issuerUrl string, re
 			return "", fmt.Errorf("error parsing realm URL: %v", err)
 		}
 		parsedUrl = parsedUrl.JoinPath("protocol/openid-connect/token")
-		updatedCreds, err := RefreshCredentials(creds.RefreshToken, parsedUrl.String(), clientId)
+		updatedCreds, err := RefreshCredentials(serverAddress, creds.RefreshToken, parsedUrl.String(), clientId)
 		if err != nil {
 			return "", fmt.Errorf("%w: %v", ErrGettingRefreshToken, err)
 		}
@@ -238,7 +253,7 @@ func extractWWWAuthenticateRealm(header string) string {
 }
 
 // RefreshCredentials uses a refresh token to get and save a new set of credentials
-func RefreshCredentials(refreshToken string, realmUrl string, clientId string) (OpenIdCredentials, error) {
+func RefreshCredentials(serverAddress string, refreshToken string, realmUrl string, clientId string) (OpenIdCredentials, error) {
 
 	data := url.Values{}
 	data.Set("client_id", clientId)
@@ -273,7 +288,7 @@ func RefreshCredentials(refreshToken string, realmUrl string, clientId string) (
 		RefreshToken:         tokens.RefreshToken,
 		AccessTokenExpiresAt: time.Now().Add(time.Duration(tokens.AccessTokenExpiresIn) * time.Second),
 	}
-	_, err = SaveCredentials(updatedCredentials)
+	_, err = SaveCredentials(serverAddress, updatedCredentials)
 	if err != nil {
 		return OpenIdCredentials{}, fmt.Errorf("error saving credentials: %v", err)
 	}
@@ -282,8 +297,8 @@ func RefreshCredentials(refreshToken string, realmUrl string, clientId string) (
 }
 
 // LoadCredentials loads the credentials from a file
-func LoadCredentials() (OpenIdCredentials, error) {
-	filePath, err := getCredentialsPath()
+func LoadCredentials(serverAddress string) (OpenIdCredentials, error) {
+	filePath, err := getCredentialsPath(serverAddress, false)
 	if err != nil {
 		return OpenIdCredentials{}, fmt.Errorf("error getting credentials path: %v", err)
 	}

--- a/internal/util/cli/credentials_test.go
+++ b/internal/util/cli/credentials_test.go
@@ -130,9 +130,11 @@ func TestSaveCredentials(t *testing.T) {
 
 	cfgPath := filepath.Join(testDir, "minder")
 
-	expectedFilePath := filepath.Join(cfgPath, "credentials.json")
+	serverAddress := "localhost:8081"
 
-	filePath, err := cli.SaveCredentials(tokens)
+	expectedFilePath := filepath.Join(cfgPath, "localhost_8081.json")
+
+	filePath, err := cli.SaveCredentials(serverAddress, tokens)
 	require.NoError(t, err)
 
 	if filePath != expectedFilePath {
@@ -162,7 +164,9 @@ func TestRemoveCredentials(t *testing.T) {
 	setEnvVar(t, XdgConfigHomeEnvVar, testDir)
 	xdgConfigHome := os.Getenv(XdgConfigHomeEnvVar)
 
-	filePath := filepath.Join(xdgConfigHome, "minder", "credentials.json")
+	serverAddress := "localhost:8081"
+
+	filePath := filepath.Join(xdgConfigHome, "minder", "localhost_8081.json")
 
 	// Create a dummy credentials file
 	err := os.MkdirAll(filepath.Dir(filePath), 0750)
@@ -176,7 +180,7 @@ func TestRemoveCredentials(t *testing.T) {
 		t.Fatalf("error writing credentials to file: %v", err)
 	}
 
-	err = cli.RemoveCredentials()
+	err = cli.RemoveCredentials(serverAddress)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -247,7 +251,7 @@ func TestRefreshCredentials(t *testing.T) {
 
 			tt.issuerUrl = server.URL
 
-			result, err := cli.RefreshCredentials(tt.refreshToken, tt.issuerUrl, tt.clientId)
+			result, err := cli.RefreshCredentials("localhost:8081", tt.refreshToken, tt.issuerUrl, tt.clientId)
 			if tt.expectedError != "" {
 				if err == nil || err.Error() != tt.expectedError {
 					t.Errorf("expected error %v, got %v", tt.expectedError, err)
@@ -270,12 +274,23 @@ func TestRefreshCredentials(t *testing.T) {
 func TestLoadCredentials(t *testing.T) {
 	tests := []struct {
 		name           string
+		filePath       string
 		fileContent    string
 		expectedError  string
 		expectedResult cli.OpenIdCredentials
 	}{
 		{
 			name:        "Successful load",
+			fileContent: `{"access_token":"access_token","refresh_token":"refresh_token","expiry":"2024-10-05T17:46:27+10:00"}`,
+			expectedResult: cli.OpenIdCredentials{
+				AccessToken:          "access_token",
+				RefreshToken:         "refresh_token",
+				AccessTokenExpiresAt: time.Date(2024, 10, 5, 17, 46, 27, 0, time.FixedZone("AEST", 10*60*60)),
+			},
+		},
+		{
+			name:        "Load from default",
+			filePath:    "minder/credentials.json",
 			fileContent: `{"access_token":"access_token","refresh_token":"refresh_token","expiry":"2024-10-05T17:46:27+10:00"}`,
 			expectedResult: cli.OpenIdCredentials{
 				AccessToken:          "access_token",
@@ -307,7 +322,11 @@ func TestLoadCredentials(t *testing.T) {
 				t.Fatalf("failed to create minder directory: %v", err)
 			}
 
-			filePath := filepath.Join(minderDir, "credentials.json")
+			serverAddress := "localhost:8081"
+			filePath := filepath.Join(minderDir, "localhost_8081.json")
+			if tt.filePath != "" {
+				filePath = filepath.Join(testDir, tt.filePath)
+			}
 
 			if tt.fileContent != "" {
 				// Create a temporary file with the specified content
@@ -319,7 +338,7 @@ func TestLoadCredentials(t *testing.T) {
 				t.Logf("Test %s: file path %s not created as file content is empty", tt.name, filePath)
 			}
 
-			result, err := cli.LoadCredentials()
+			result, err := cli.LoadCredentials(serverAddress)
 			if tt.expectedError != "" {
 				if err == nil || !strings.HasPrefix(err.Error(), tt.expectedError) {
 					t.Errorf("expected error matching %v, got %v", tt.expectedError, err)

--- a/internal/util/cli/credentials_test.go
+++ b/internal/util/cli/credentials_test.go
@@ -29,6 +29,8 @@ var (
 	XdgConfigHomeEnvVar = "XDG_CONFIG_HOME"
 )
 
+const serverAddress = "localhost:8081"
+
 // Enforce that only one test setting environment variables runs at a time
 func setEnvVar(t *testing.T, env string, value string) {
 	t.Helper() // Keep golangci-lint happy
@@ -130,8 +132,6 @@ func TestSaveCredentials(t *testing.T) {
 
 	cfgPath := filepath.Join(testDir, "minder")
 
-	serverAddress := "localhost:8081"
-
 	expectedFilePath := filepath.Join(cfgPath, "localhost_8081.json")
 
 	filePath, err := cli.SaveCredentials(serverAddress, tokens)
@@ -163,8 +163,6 @@ func TestRemoveCredentials(t *testing.T) {
 	testDir := t.TempDir()
 	setEnvVar(t, XdgConfigHomeEnvVar, testDir)
 	xdgConfigHome := os.Getenv(XdgConfigHomeEnvVar)
-
-	serverAddress := "localhost:8081"
 
 	filePath := filepath.Join(xdgConfigHome, "minder", "localhost_8081.json")
 
@@ -322,7 +320,6 @@ func TestLoadCredentials(t *testing.T) {
 				t.Fatalf("failed to create minder directory: %v", err)
 			}
 
-			serverAddress := "localhost:8081"
 			filePath := filepath.Join(minderDir, "localhost_8081.json")
 			if tt.filePath != "" {
 				filePath = filepath.Join(testDir, tt.filePath)

--- a/internal/util/cli/rpc_client.go
+++ b/internal/util/cli/rpc_client.go
@@ -128,11 +128,12 @@ func LoginAndSaveCreds(ctx context.Context, cmd *cobra.Command, clientConfig *cl
 	}
 
 	// save credentials
-	filePath, err := SaveCredentials(OpenIdCredentials{
-		AccessToken:          token.AccessToken,
-		RefreshToken:         token.RefreshToken,
-		AccessTokenExpiresAt: token.Expiry,
-	})
+	filePath, err := SaveCredentials(clientConfig.GRPCClientConfig.GetGRPCAddress(),
+		OpenIdCredentials{
+			AccessToken:          token.AccessToken,
+			RefreshToken:         token.RefreshToken,
+			AccessTokenExpiresAt: token.Expiry,
+		})
 	if err != nil {
 		cmd.PrintErrf("couldn't save credentials: %s\n", err)
 		return "", err


### PR DESCRIPTION
# Summary

Currently, the `minder` CLI uses a single credential file for all providers.  When working across providers, this means that you constantly need to re-run `minder auth login`, which is annoying.  Use a different file for each API endpoint.

Fixes #1961

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Updated tests and ran manual tests.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
