### PR TITLE
Update email template context to include invite code and project ID

### DIFF
--- a/cmd/server/kodata/templates/invite-email.txt.tmpl
+++ b/cmd/server/kodata/templates/invite-email.txt.tmpl
@@ -2,7 +2,11 @@
 
 View Invitation: {{.InvitationURL}}
 
-Once you accept, you’ll be able to {{.RoleVerb}} the {{.OrganizationName}} organization in Minder by Stacklok.
+Once you accept, you’ll be able to {{.RoleVerb}} the {{.OrganizationName}} organization in Minder by Stacklok.  If you have the Minder CLI installed, you can accept the invite with:
+
+minder auth invite accept {{ .InvitationCode }}
+
+If you are a member of multiple organizations, you can use the --project {{ .OrganizationId }} flag to specify which organization you want the Minder CLI to operate on.
 
 This invitation was sent to {{.RecipientEmail}}. If you were not expecting it, you can ignore this email.
 

--- a/internal/email/email_test.go
+++ b/internal/email/email_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/google/uuid"
 )
 
 func TestIsValidField(t *testing.T) {
@@ -56,6 +58,8 @@ func TestIsValidField(t *testing.T) {
 func TestValidateDataSourceTemplate(t *testing.T) {
 	t.Parallel()
 
+	projectId := uuid.New()
+
 	tests := []struct {
 		input          bodyData
 		expectedErrMsg string
@@ -64,7 +68,9 @@ func TestValidateDataSourceTemplate(t *testing.T) {
 		{
 			bodyData{
 				AdminName:        "John Doe",
+				OrganizationId:   projectId,
 				OrganizationName: "Acme Corp",
+				InvitationCode:   "ABC123",
 				InvitationURL:    "https://invitation.com",
 				RecipientEmail:   "john.doe@example.com",
 				MinderURL:        "https://minder.com",
@@ -81,7 +87,9 @@ func TestValidateDataSourceTemplate(t *testing.T) {
 		{
 			bodyData{
 				AdminName:        "John <b>Doe</b>",
+				OrganizationId:   projectId,
 				OrganizationName: "Acme Corp",
+				InvitationCode:   "ABC123",
 				InvitationURL:    "https://invitation.com",
 				RecipientEmail:   "john.doe@example.com",
 				MinderURL:        "https://minder.com",
@@ -98,7 +106,9 @@ func TestValidateDataSourceTemplate(t *testing.T) {
 		{
 			bodyData{
 				AdminName:        "John Doe",
+				OrganizationId:   projectId,
 				OrganizationName: "<script>alert('Hack');</script>",
+				InvitationCode:   "ABC123",
 				InvitationURL:    "https://invitation.com",
 				RecipientEmail:   "john.doe@example.com",
 				MinderURL:        "https://minder.com",
@@ -115,7 +125,9 @@ func TestValidateDataSourceTemplate(t *testing.T) {
 		{
 			bodyData{
 				AdminName:        "onload=alert('test')",
+				OrganizationId:   projectId,
 				OrganizationName: "Acme Corp",
+				InvitationCode:   "ABC123",
 				InvitationURL:    "https://invitation.com",
 				RecipientEmail:   "john.doe@example.com",
 				MinderURL:        "https://minder.com",
@@ -132,7 +144,9 @@ func TestValidateDataSourceTemplate(t *testing.T) {
 		{
 			bodyData{
 				AdminName:        "Plain Text User",
+				OrganizationId:   projectId,
 				OrganizationName: "No HTML Corp",
+				InvitationCode:   "ABC123",
 				InvitationURL:    "https://example.com",
 				RecipientEmail:   "user@example.com",
 				MinderURL:        "https://example.com/minder",
@@ -151,7 +165,7 @@ func TestValidateDataSourceTemplate(t *testing.T) {
 		t.Run(tt.input.AdminName, func(t *testing.T) {
 			t.Parallel()
 			err := tt.input.Validate()
-			if err != nil && err.Error() != tt.expectedErrMsg {
+			if err != nil && !strings.Contains(err.Error(), tt.expectedErrMsg) {
 				t.Errorf("validateDataSourceTemplate(%+v) got error message: %v, expected message: %v", tt.input, err.Error(), tt.expectedErrMsg)
 			}
 		})

--- a/internal/invites/service.go
+++ b/internal/invites/service.go
@@ -118,9 +118,11 @@ func (*inviteService) UpdateInvite(ctx context.Context, qtx db.Querier, eventsPu
 		msg, err := email.NewMessage(
 			ctx,
 			userInvite.Email,
+			userInvite.Code,
 			inviteURL,
 			emailConfig.MinderURLBase,
 			userInvite.Role,
+			prj.ID,
 			meta.Public.DisplayName,
 			identity.Human(),
 		)
@@ -290,9 +292,11 @@ func (*inviteService) CreateInvite(ctx context.Context, qtx db.Querier, eventsPu
 	msg, err := email.NewMessage(
 		ctx,
 		userInvite.Email,
+		userInvite.Code,
 		inviteURL,
 		emailConfig.MinderURLBase,
 		userInvite.Role,
+		prj.ID,
 		meta.Public.DisplayName,
 		identity.Human(),
 	)

--- a/internal/invites/service_test.go
+++ b/internal/invites/service_test.go
@@ -37,7 +37,8 @@ func TestMain(m *testing.M) {
 		fmt.Printf("error setting KO_DATA_PATH: %v\n", err)
 		os.Exit(1)
 	}
-	_, err = email.NewMessage(context.Background(), "j@example.com", "http://example.com/invite", "http://api.example.com/", "admin", "Example", "Joe")
+	projectId := uuid.New()
+	_, err = email.NewMessage(context.Background(), "j@example.com", "ABC123", "http://example.com/invite", "http://api.example.com/", "admin", projectId, "Example", "Joe")
 	if err != nil {
 		fmt.Printf("error creating message: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
# Summary

It turns out that we support delivering the invitation code in a larger URL, but we do not supply the invitation code directly to the template (for example, to use in CLI directions).

I also added the UUID project ID to the context, as that's the only form of project ID that the CLI currently supports.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
