### PR TITLE
Enable CreateProject and DeleteProject on top-level projects

### DIFF
--- a/internal/controlplane/handlers_authz_test.go
+++ b/internal/controlplane/handlers_authz_test.go
@@ -271,6 +271,7 @@ func TestProjectAuthorizationInterceptor(t *testing.T) {
 
 			rpcOptions := &minder.RpcOptions{
 				TargetResource: tc.resource,
+				Relation:       minder.Relation_RELATION_PROFILE_CREATE,
 			}
 
 			unaryHandler := func(ctx context.Context, _ interface{}) (any, error) {

--- a/internal/controlplane/handlers_reconciliationtasks_test.go
+++ b/internal/controlplane/handlers_reconciliationtasks_test.go
@@ -20,10 +20,11 @@ import (
 	pb "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
 )
 
+const ghProvider = "github"
+
 func TestServer_CreateRepositoryReconciliationTask(t *testing.T) {
 	t.Parallel()
 
-	ghProvider := "github"
 	repoUuid := uuid.New()
 	tests := []struct {
 		name          string

--- a/pkg/api/protobuf/go/minder/v1/minder.pb.go
+++ b/pkg/api/protobuf/go/minder/v1/minder.pb.go
@@ -15903,7 +15903,7 @@ const file_minder_v1_minder_proto_rawDesc = "" +
 	"RemoveRole\x12\x1c.minder.v1.RemoveRoleRequest\x1a\x1d.minder.v1.RemoveRoleResponse\"*\xaa\xf8\x18\x040\x038\b\x82\xd3\xe4\x93\x02\x1c*\x1a/api/v1/permissions/remove2\xc5\a\n" +
 	"\x0fProjectsService\x12q\n" +
 	"\fListProjects\x12\x1e.minder.v1.ListProjectsRequest\x1a\x1f.minder.v1.ListProjectsResponse\" \xaa\xf8\x18\x040\x028\x02\x82\xd3\xe4\x93\x02\x12\x12\x10/api/v1/projects\x12w\n" +
-	"\rCreateProject\x12\x1f.minder.v1.CreateProjectRequest\x1a .minder.v1.CreateProjectResponse\"#\xaa\xf8\x18\x040\x038\x01\x82\xd3\xe4\x93\x02\x15:\x01*\"\x10/api/v1/projects\x12\x9e\x01\n" +
+	"\rCreateProject\x12\x1f.minder.v1.CreateProjectRequest\x1a .minder.v1.CreateProjectResponse\"#\xaa\xf8\x18\x040\x028\x01\x82\xd3\xe4\x93\x02\x15:\x01*\"\x10/api/v1/projects\x12\x9e\x01\n" +
 	"\x11ListChildProjects\x12#.minder.v1.ListChildProjectsRequest\x1a$.minder.v1.ListChildProjectsResponse\">\xaa\xf8\x18\x040\x038\x02\x82\xd3\xe4\x93\x020\x12./api/v1/projects/{context.project_id}/children\x12t\n" +
 	"\rDeleteProject\x12\x1f.minder.v1.DeleteProjectRequest\x1a .minder.v1.DeleteProjectResponse\" \xaa\xf8\x18\x040\x038\x04\x82\xd3\xe4\x93\x02\x12*\x10/api/v1/projects\x12w\n" +
 	"\rUpdateProject\x12\x1f.minder.v1.UpdateProjectRequest\x1a .minder.v1.UpdateProjectResponse\"#\xaa\xf8\x18\x040\x038\x03\x82\xd3\xe4\x93\x02\x15:\x01*\x1a\x10/api/v1/projects\x12x\n" +

--- a/pkg/flags/constants.go
+++ b/pkg/flags/constants.go
@@ -18,4 +18,6 @@ const (
 	GitPRDiffs Experiment = "git_pr_diffs"
 	// DependencyExtract enables functions to perform dependency extraction.
 	DependencyExtract Experiment = "dependency_extract"
+	// ProjectCreateDelete enables creating top-level projects and deleting them.
+	ProjectCreateDelete Experiment = "project_create_delete"
 )

--- a/proto/minder/v1/minder.proto
+++ b/proto/minder/v1/minder.proto
@@ -903,7 +903,10 @@ service ProjectsService {
         };
 
         option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
+            // We use TARGET_RESOURCE_USER (no specific resource is checked for authz)
+            // here when creating top-level projects, and specifically check the
+            // RELATION_CREATE permission when creating sub-projects under a parent.
+            target_resource: TARGET_RESOURCE_USER
             relation: RELATION_CREATE
         };
     }


### PR DESCRIPTION
# Summary

Allow CreateProject (with auth but no permission check) on top-level projects.

Allow DeleteProject (with required project permissions) on top-level projects.

Both changes are behind a new feature flag.

Fixes #3173
Fixes #3174

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Added a few unit tests, also doing some manual testing.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
