### PR TITLE
Add support for service admins to delete resources via API

### DIFF
--- a/pkg/config/server/authz.go
+++ b/pkg/config/server/authz.go
@@ -21,6 +21,10 @@ type AuthzConfig struct {
 	ModelID string `mapstructure:"model_id" default:""`
 	// Auth is the authentication configuration for the authorization server
 	Auth OpenFGAAuth `mapstructure:"auth" validate:"required"`
+
+	// AdminDeleters are a list of user IDs in the authz system which are
+	// permitted to delete resources from the system.
+	AdminDeleters []string `mapstructure:"admin_deleters" default:""`
 }
 
 // Validate validates the Authz configuration


### PR DESCRIPTION
# Summary

This change allows a set of server admins (Keycloak user IDs listed in the server configuration file) to delete offending resources via the front-door API.  This only supports delete, so server admins need to already know the identity of the offending resource (as the probably have access to the backing database).  Deleting these resources through the API ensures that _other_ cleanup (e.g. webhook deregistration and other updates) is performed when compared with simply deleting rows from the backend.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Added unit testing, some manual testing.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
