### PR TITLE
Simplify interfaces in RTEngine

### DIFF
--- a/cmd/dev/app/rule_type/rttst.go
+++ b/cmd/dev/app/rule_type/rttst.go
@@ -197,7 +197,8 @@ func testCmdRun(cmd *cobra.Command, _ []string) error {
 
 	// TODO: use cobra context here
 	ctx := context.Background()
-	eng, err := rtengine.NewRuleTypeEngine(ctx, ruletype, prov, nil /*experiments*/, options.WithDataSources(dsRegistry))
+	// TODO: accomodate flags here or enable them all
+	eng, err := rtengine.NewRuleTypeEngine(ctx, ruletype, prov, options.WithDataSources(dsRegistry))
 	if err != nil {
 		return fmt.Errorf("cannot create rule type engine: %w", err)
 	}

--- a/internal/datasources/rest/handler.go
+++ b/internal/datasources/rest/handler.go
@@ -129,7 +129,7 @@ func (h *restHandler) ValidateUpdate(argsSchema *structpb.Struct) error {
 	return schemaupdate.ValidateSchemaUpdate(h.rawInputSchema, argsSchema)
 }
 
-func (h *restHandler) Call(ctx context.Context, _ *interfaces.Result, args any) (any, error) {
+func (h *restHandler) Call(ctx context.Context, _ *interfaces.Ingested, args any) (any, error) {
 	argsMap, ok := args.(map[string]any)
 	if !ok {
 		return nil, errors.New("args is not a map")

--- a/internal/datasources/structured/handler.go
+++ b/internal/datasources/structured/handler.go
@@ -150,7 +150,7 @@ func parseFile(f billy.File) (any, error) {
 }
 
 // Call parses the structured data from the billy filesystem in the context
-func (sh *structHandler) Call(_ context.Context, ingest *interfaces.Result, _ any) (any, error) {
+func (sh *structHandler) Call(_ context.Context, ingest *interfaces.Ingested, _ any) (any, error) {
 	if ingest == nil || ingest.Fs == nil {
 		return nil, fmt.Errorf("filesystem not found in execution context")
 	}

--- a/internal/datasources/structured/handler_test.go
+++ b/internal/datasources/structured/handler_test.go
@@ -166,18 +166,18 @@ func TestCall(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
 		name    string
-		ingest  func(t *testing.T) *interfaces.Result
+		ingest  func(t *testing.T) *interfaces.Ingested
 		def     *minderv1.StructDataSource_Def
 		mustErr bool
 	}{
 		{
 			"success",
-			func(t *testing.T) *interfaces.Result {
+			func(t *testing.T) *interfaces.Ingested {
 				t.Helper()
 				fs := memfs.New()
 				writeFSFile(t, fs, "./test1.json", []byte("{ \"a\": \"b\"}"))
 
-				return &interfaces.Result{Fs: fs}
+				return &interfaces.Ingested{Fs: fs}
 			},
 			&minderv1.StructDataSource_Def{
 				Path: &minderv1.StructDataSource_Def_Path{
@@ -188,7 +188,7 @@ func TestCall(t *testing.T) {
 		},
 		{
 			"no-datasource-context",
-			func(t *testing.T) *interfaces.Result {
+			func(t *testing.T) *interfaces.Ingested {
 				t.Helper()
 				return nil
 			},
@@ -196,9 +196,9 @@ func TestCall(t *testing.T) {
 			true,
 		},
 		{"ctx-no-fs",
-			func(t *testing.T) *interfaces.Result {
+			func(t *testing.T) *interfaces.Ingested {
 				t.Helper()
-				return &interfaces.Result{}
+				return &interfaces.Ingested{}
 			},
 			&minderv1.StructDataSource_Def{},
 			true},

--- a/internal/engine/actions/remediate/pull_request/pull_request.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request.go
@@ -76,7 +76,7 @@ type Remediator struct {
 }
 
 type paramsPR struct {
-	ingested   *engifv1.Result
+	ingested   *engifv1.Ingested
 	repo       *pb.Repository
 	title      string
 	modifier   fsModifier

--- a/internal/engine/actions/remediate/pull_request/pull_request_test.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request_test.go
@@ -681,7 +681,7 @@ func TestPullRequestRemediate(t *testing.T) {
 			require.NoError(t, err, "unexpected error creating test worktree")
 
 			evalParams.SetIngestResult(
-				&interfaces2.Result{
+				&interfaces2.Ingested{
 					Fs:     testWt.Filesystem,
 					Storer: testrepo.Storer,
 				})

--- a/internal/engine/eval/eval.go
+++ b/internal/engine/eval/eval.go
@@ -18,7 +18,6 @@ import (
 	eoptions "github.com/mindersec/minder/internal/engine/options"
 	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
 	"github.com/mindersec/minder/pkg/engine/v1/interfaces"
-	"github.com/mindersec/minder/pkg/flags"
 	provinfv1 "github.com/mindersec/minder/pkg/providers/v1"
 )
 
@@ -27,7 +26,6 @@ func NewRuleEvaluator(
 	ctx context.Context,
 	ruletype *minderv1.RuleType,
 	provider provinfv1.Provider,
-	featureFlags flags.Interface,
 	opts ...eoptions.Option,
 ) (interfaces.Evaluator, error) {
 	e := ruletype.Def.GetEval()
@@ -43,7 +41,7 @@ func NewRuleEvaluator(
 		}
 		return jq.NewJQEvaluator(e.GetJq(), opts...)
 	case rego.RegoEvalType:
-		return rego.NewRegoEvaluator(e.GetRego(), featureFlags, opts...)
+		return rego.NewRegoEvaluator(e.GetRego(), opts...)
 	case vulncheck.VulncheckEvalType:
 		client, err := provinfv1.As[provinfv1.GitHub](provider)
 		if err != nil {

--- a/internal/engine/eval/eval_test.go
+++ b/internal/engine/eval/eval_test.go
@@ -71,7 +71,7 @@ func TestNewRuleEvaluatorWorks(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := eval.NewRuleEvaluator(context.Background(), tt.args.rt, nil, nil)
+			got, err := eval.NewRuleEvaluator(context.Background(), tt.args.rt, nil)
 			assert.NoError(t, err, "unexpected error")
 			assert.NotNil(t, got, "unexpected nil")
 		})
@@ -146,7 +146,7 @@ func TestNewRuleEvaluatorFails(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := eval.NewRuleEvaluator(context.Background(), tt.args.rt, nil, nil)
+			got, err := eval.NewRuleEvaluator(context.Background(), tt.args.rt, nil)
 			assert.Error(t, err, "should have errored")
 			assert.Nil(t, got, "should be nil")
 		})

--- a/internal/engine/eval/homoglyphs/application/homoglyphs_service.go
+++ b/internal/engine/eval/homoglyphs/application/homoglyphs_service.go
@@ -59,7 +59,7 @@ func NewHomoglyphsEvaluator(
 func evaluateHomoglyphs(
 	ctx context.Context,
 	processor domain.HomoglyphProcessor,
-	res *interfaces.Result,
+	res *interfaces.Ingested,
 	reviewHandler *communication.GhReviewPrHandler,
 ) ([]*domain.Violation, error) {
 	// create an empty list of violations

--- a/internal/engine/eval/homoglyphs/application/invisible_characters_eval.go
+++ b/internal/engine/eval/homoglyphs/application/invisible_characters_eval.go
@@ -48,7 +48,7 @@ func (ice *InvisibleCharactersEvaluator) Eval(
 	ctx context.Context,
 	_ map[string]any,
 	_ protoreflect.ProtoMessage,
-	res *interfaces.Result,
+	res *interfaces.Ingested,
 ) (*interfaces.EvaluationResult, error) {
 	violations, err := evaluateHomoglyphs(ctx, ice.processor, res, ice.reviewHandler)
 	if err != nil {

--- a/internal/engine/eval/homoglyphs/application/mixed_scripts_eval.go
+++ b/internal/engine/eval/homoglyphs/application/mixed_scripts_eval.go
@@ -54,7 +54,7 @@ func (mse *MixedScriptsEvaluator) Eval(
 	ctx context.Context,
 	_ map[string]any,
 	_ protoreflect.ProtoMessage,
-	res *interfaces.Result,
+	res *interfaces.Ingested,
 ) (*interfaces.EvaluationResult, error) {
 	violations, err := evaluateHomoglyphs(ctx, mse.processor, res, mse.reviewHandler)
 	if err != nil {

--- a/internal/engine/eval/jq/fuzz_test.go
+++ b/internal/engine/eval/jq/fuzz_test.go
@@ -38,6 +38,6 @@ func FuzzJqEval(f *testing.F) {
 		}
 
 		//nolint:gosec // Do not validate the return values so ignore them
-		jqe.Eval(context.Background(), pol, nil, &interfaces.Result{Object: obj})
+		jqe.Eval(context.Background(), pol, nil, &interfaces.Ingested{Object: obj})
 	})
 }

--- a/internal/engine/eval/jq/jq.go
+++ b/internal/engine/eval/jq/jq.go
@@ -60,7 +60,7 @@ func (jqe *Evaluator) Eval(
 	ctx context.Context,
 	pol map[string]any,
 	_ protoreflect.ProtoMessage,
-	res *interfaces.Result,
+	res *interfaces.Ingested,
 ) (*interfaces.EvaluationResult, error) {
 	if res.Object == nil {
 		return nil, fmt.Errorf("missing object")

--- a/internal/engine/eval/jq/jq_test.go
+++ b/internal/engine/eval/jq/jq_test.go
@@ -366,7 +366,7 @@ func TestValidJQEvals(t *testing.T) {
 			assert.NoError(t, err, "Got unexpected error")
 			assert.NotNil(t, jqe, "Got unexpected nil")
 
-			_, err = jqe.Eval(context.Background(), tt.args.pol, nil, &interfaces.Result{Object: tt.args.obj})
+			_, err = jqe.Eval(context.Background(), tt.args.pol, nil, &interfaces.Ingested{Object: tt.args.obj})
 			assert.NoError(t, err, "Got unexpected error")
 		})
 	}
@@ -576,7 +576,7 @@ func TestValidJQEvalsFailed(t *testing.T) {
 			assert.NoError(t, err, "Got unexpected error")
 			assert.NotNil(t, jqe, "Got unexpected nil")
 
-			_, err = jqe.Eval(context.Background(), tt.args.pol, nil, &interfaces.Result{Object: tt.args.obj})
+			_, err = jqe.Eval(context.Background(), tt.args.pol, nil, &interfaces.Ingested{Object: tt.args.obj})
 			assert.ErrorIs(t, err, evalerrors.ErrEvaluationFailed, "Got unexpected error")
 		})
 	}

--- a/internal/engine/eval/rego/datasources.go
+++ b/internal/engine/eval/rego/datasources.go
@@ -22,7 +22,7 @@ func (e *Evaluator) RegisterDataSources(dsr *v1datasources.DataSourceRegistry) {
 
 // buildDataSourceOptions creates an options set from the functions available in
 // a data source registry.
-func buildDataSourceOptions(res *interfaces.Result, dsr *v1datasources.DataSourceRegistry) []func(*rego.Rego) {
+func buildDataSourceOptions(res *interfaces.Ingested, dsr *v1datasources.DataSourceRegistry) []func(*rego.Rego) {
 	opts := []func(*rego.Rego){}
 	if dsr == nil {
 		return opts
@@ -39,7 +39,7 @@ func buildDataSourceOptions(res *interfaces.Result, dsr *v1datasources.DataSourc
 // It takes a DataSourceFuncDef and returns a function that can be used to
 // register the function with the rego engine.
 func buildFromDataSource(
-	res *interfaces.Result, key v1datasources.DataSourceFuncKey, dsf v1datasources.DataSourceFuncDef,
+	res *interfaces.Ingested, key v1datasources.DataSourceFuncKey, dsf v1datasources.DataSourceFuncDef,
 ) func(*rego.Rego) {
 	k := normalizeKey(key)
 	return rego.Function1(

--- a/internal/engine/eval/rego/eval.go
+++ b/internal/engine/eval/rego/eval.go
@@ -115,6 +115,7 @@ func (e *Evaluator) newRegoFromOptions(opts ...func(*rego.Rego)) *rego.Rego {
 	return rego.New(append(e.regoOpts, opts...)...)
 }
 
+// SetFlagsClient implements the SupportsFlags interface.
 func (e *Evaluator) SetFlagsClient(client flags.Interface) error {
 	e.featureFlags = client
 	return nil

--- a/internal/engine/eval/rego/fuzz_test.go
+++ b/internal/engine/eval/rego/fuzz_test.go
@@ -20,7 +20,6 @@ func FuzzRegoEval(f *testing.F) {
 				Type: ConstraintsEvaluationType.String(),
 				Def:  policy,
 			},
-			nil,
 		)
 		if err != nil {
 			return
@@ -32,7 +31,7 @@ func FuzzRegoEval(f *testing.F) {
 		// The fuzzer tests for unexpected behavior, so it is not
 		// important what e.Eval() returns.
 		//nolint:gosec // Ignore the return values from e.Eval()
-		e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+		e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 			Object: map[string]any{
 				"data": data,
 			},

--- a/internal/engine/eval/rego/http_test.go
+++ b/internal/engine/eval/rego/http_test.go
@@ -61,13 +61,12 @@ func TestLimitedDialer(t *testing.T) {
 					Type: rego.DenyByDefaultEvaluationType.String(),
 					Def:  fmt.Sprintf(ruleDef, tt.url),
 				},
-				nil,
 			)
 			require.NoError(t, err, "could not create evaluator")
 
 			emptyPol := map[string]any{}
 
-			res, err := eval.Eval(context.Background(), emptyPol, nil, &interfaces.Result{})
+			res, err := eval.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{})
 
 			if tt.wantErr == "" {
 				require.NoError(t, err, "expected no error")

--- a/internal/engine/eval/rego/lib.go
+++ b/internal/engine/eval/rego/lib.go
@@ -37,7 +37,7 @@ import (
 )
 
 // MinderRegoLib contains the minder-specific functions for rego
-var MinderRegoLib = []func(res *interfaces.Result) func(*rego.Rego){
+var MinderRegoLib = []func(res *interfaces.Ingested) func(*rego.Rego){
 	FileExists,
 	FileLs,
 	FileLsGlob,
@@ -54,7 +54,7 @@ var MinderRegoLib = []func(res *interfaces.Result) func(*rego.Rego){
 
 // MinderRegoLibExperiments contains Minder-specific functions which
 // should only be exposed when the given experiment is enabled.
-var MinderRegoLibExperiments = map[flags.Experiment][]func(res *interfaces.Result) func(*rego.Rego){
+var MinderRegoLibExperiments = map[flags.Experiment][]func(res *interfaces.Ingested) func(*rego.Rego){
 	flags.GitPRDiffs: {
 		BaseFileExists,
 		BaseFileLs,
@@ -70,7 +70,7 @@ var MinderRegoLibExperiments = map[flags.Experiment][]func(res *interfaces.Resul
 	},
 }
 
-func instantiateRegoLib(ctx context.Context, featureFlags flags.Interface, res *interfaces.Result) []func(*rego.Rego) {
+func instantiateRegoLib(ctx context.Context, featureFlags flags.Interface, res *interfaces.Ingested) []func(*rego.Rego) {
 	var lib []func(*rego.Rego)
 	for _, f := range MinderRegoLib {
 		lib = append(lib, f(res))
@@ -86,7 +86,7 @@ func instantiateRegoLib(ctx context.Context, featureFlags flags.Interface, res *
 }
 
 // FileExists adds the `file.exists` function to the Rego engine.
-func FileExists(res *interfaces.Result) func(*rego.Rego) {
+func FileExists(res *interfaces.Ingested) func(*rego.Rego) {
 	return rego.Function1(
 		&rego.Function{
 			Name: "file.exists",
@@ -101,7 +101,7 @@ func FileExists(res *interfaces.Result) func(*rego.Rego) {
 }
 
 // BaseFileExists adds the `base_file.exists` function to the Rego engine.
-func BaseFileExists(res *interfaces.Result) func(*rego.Rego) {
+func BaseFileExists(res *interfaces.Ingested) func(*rego.Rego) {
 	return rego.Function1(
 		&rego.Function{
 			Name: "base_file.exists",
@@ -141,7 +141,7 @@ func fsExists(vfs billy.Filesystem) func(rego.BuiltinContext, *ast.Term) (*ast.T
 }
 
 // FileRead adds the `file.read` function to the Rego engine.
-func FileRead(res *interfaces.Result) func(*rego.Rego) {
+func FileRead(res *interfaces.Ingested) func(*rego.Rego) {
 	return rego.Function1(
 		&rego.Function{
 			Name: "file.read",
@@ -156,7 +156,7 @@ func FileRead(res *interfaces.Result) func(*rego.Rego) {
 }
 
 // BaseFileRead adds the `base_file.read` function to the Rego engine.
-func BaseFileRead(res *interfaces.Result) func(*rego.Rego) {
+func BaseFileRead(res *interfaces.Ingested) func(*rego.Rego) {
 	return rego.Function1(
 		&rego.Function{
 			Name: "base_file.read",
@@ -200,7 +200,7 @@ func fsRead(vfs billy.Filesystem) func(rego.BuiltinContext, *ast.Term) (*ast.Ter
 }
 
 // FileLs adds the `file.ls` function to the Rego engine.
-func FileLs(res *interfaces.Result) func(*rego.Rego) {
+func FileLs(res *interfaces.Ingested) func(*rego.Rego) {
 	return rego.Function1(
 		&rego.Function{
 			Name: "file.ls",
@@ -226,7 +226,7 @@ func FileLs(res *interfaces.Result) func(*rego.Rego) {
 // If the file is a directory, it returns the files in the directory.
 // If the file is a symlink, it follows the symlink and returns the files
 // in the target.
-func BaseFileLs(res *interfaces.Result) func(*rego.Rego) {
+func BaseFileLs(res *interfaces.Ingested) func(*rego.Rego) {
 	return rego.Function1(
 		&rego.Function{
 			Name: "base_file.ls",
@@ -303,7 +303,7 @@ func fsLs(vfs billy.Filesystem) func(rego.BuiltinContext, *ast.Term) (*ast.Term,
 }
 
 // FileLsGlob adds the `file.ls_glob` function to the Rego engine.
-func FileLsGlob(res *interfaces.Result) func(*rego.Rego) {
+func FileLsGlob(res *interfaces.Ingested) func(*rego.Rego) {
 	return rego.Function1(
 		&rego.Function{
 			Name: "file.ls_glob",
@@ -318,7 +318,7 @@ func FileLsGlob(res *interfaces.Result) func(*rego.Rego) {
 }
 
 // BaseFileLsGlob adds the `base_file.ls_glob` function to the Rego engine.
-func BaseFileLsGlob(res *interfaces.Result) func(*rego.Rego) {
+func BaseFileLsGlob(res *interfaces.Ingested) func(*rego.Rego) {
 	return rego.Function1(
 		&rego.Function{
 			Name: "base_file.ls_glob",
@@ -361,7 +361,7 @@ func fsLsGlob(vfs billy.Filesystem) func(rego.BuiltinContext, *ast.Term) (*ast.T
 }
 
 // FileWalk adds the `file.walk` function to the Rego engine.
-func FileWalk(res *interfaces.Result) func(*rego.Rego) {
+func FileWalk(res *interfaces.Ingested) func(*rego.Rego) {
 	return rego.Function1(
 		&rego.Function{
 			Name: "file.walk",
@@ -376,7 +376,7 @@ func FileWalk(res *interfaces.Result) func(*rego.Rego) {
 }
 
 // BaseFileWalk adds the `base_file.walk` function to the Rego engine.
-func BaseFileWalk(res *interfaces.Result) func(*rego.Rego) {
+func BaseFileWalk(res *interfaces.Ingested) func(*rego.Rego) {
 	return rego.Function1(
 		&rego.Function{
 			Name: "base_file.walk",
@@ -472,7 +472,7 @@ func fileLsHandleDir(path string, bfs billy.Filesystem) (*ast.Term, error) {
 }
 
 // FileArchive adds the 'file.archive` function to the Rego engine.
-func FileArchive(res *interfaces.Result) func(*rego.Rego) {
+func FileArchive(res *interfaces.Ingested) func(*rego.Rego) {
 	return rego.Function1(
 		&rego.Function{
 			Name: "file.archive",
@@ -487,7 +487,7 @@ func FileArchive(res *interfaces.Result) func(*rego.Rego) {
 }
 
 // BaseFileArchive adds the 'base_file.archive` function to the Rego engine.
-func BaseFileArchive(res *interfaces.Result) func(*rego.Rego) {
+func BaseFileArchive(res *interfaces.Ingested) func(*rego.Rego) {
 	return rego.Function1(
 		&rego.Function{
 			Name: "base_file.archive",
@@ -566,7 +566,7 @@ func fsArchive(vfs billy.Filesystem) func(rego.BuiltinContext, *ast.Term) (*ast.
 
 // ListGithubActions adds the `github_workflow.ls_actions` function to the Rego engine.
 // The frizbee library guarantees that the actions are unique.
-func ListGithubActions(res *interfaces.Result) func(*rego.Rego) {
+func ListGithubActions(res *interfaces.Ingested) func(*rego.Rego) {
 	return rego.Function1(
 		&rego.Function{
 			Name: "github_workflow.ls_actions",
@@ -583,7 +583,7 @@ func ListGithubActions(res *interfaces.Result) func(*rego.Rego) {
 
 // BaseListGithubActions adds the `github_workflow.base_ls_actions` function to the Rego engine.
 // The frizbee library guarantees that the actions are unique.
-func BaseListGithubActions(res *interfaces.Result) func(*rego.Rego) {
+func BaseListGithubActions(res *interfaces.Ingested) func(*rego.Rego) {
 	return rego.Function1(
 		&rego.Function{
 			Name: "github_workflow.base_ls_actions",
@@ -628,7 +628,7 @@ func fsListGithubActions(vfs billy.Filesystem) func(rego.BuiltinContext, *ast.Te
 }
 
 // FileHTTPType adds the `file.http_type` function to the Rego engine.
-func FileHTTPType(res *interfaces.Result) func(*rego.Rego) {
+func FileHTTPType(res *interfaces.Ingested) func(*rego.Rego) {
 	return rego.Function1(
 		&rego.Function{
 			Name: "file.http_type",
@@ -644,7 +644,7 @@ func FileHTTPType(res *interfaces.Result) func(*rego.Rego) {
 }
 
 // BaseFileHTTPType adds the `base_file.http_type` function to the Rego engine.
-func BaseFileHTTPType(res *interfaces.Result) func(*rego.Rego) {
+func BaseFileHTTPType(res *interfaces.Ingested) func(*rego.Rego) {
 	return rego.Function1(
 		&rego.Function{
 			Name: "base_file.http_type",
@@ -691,7 +691,7 @@ func fsHTTPType(vfs billy.Filesystem) func(rego.BuiltinContext, *ast.Term) (*ast
 }
 
 // JQIsTrue adds the `jq.is_true` function to the Rego engine.
-func JQIsTrue(_ *interfaces.Result) func(*rego.Rego) {
+func JQIsTrue(_ *interfaces.Ingested) func(*rego.Rego) {
 	return rego.Function2(
 		&rego.Function{
 			Name: "jq.is_true",
@@ -726,7 +726,7 @@ func jqIsTrue(_ rego.BuiltinContext, parsedYaml *ast.Term, query *ast.Term) (*as
 }
 
 // ParseYaml adds the `parse_yaml` function to the Rego engine.
-func ParseYaml(_ *interfaces.Result) func(*rego.Rego) {
+func ParseYaml(_ *interfaces.Ingested) func(*rego.Rego) {
 	return rego.Function1(
 		&rego.Function{
 			Name: "parse_yaml",
@@ -764,7 +764,7 @@ func parseYaml(_ rego.BuiltinContext, yamlContent *ast.Term) (*ast.Term, error) 
 }
 
 // ParseToml adds the `parse_toml` function to the Rego engine.
-func ParseToml(_ *interfaces.Result) func(*rego.Rego) {
+func ParseToml(_ *interfaces.Ingested) func(*rego.Rego) {
 	return rego.Function1(
 		&rego.Function{
 			Name: "parse_toml",
@@ -802,7 +802,7 @@ func parseToml(_ rego.BuiltinContext, content *ast.Term) (*ast.Term, error) {
 }
 
 // DependencyExtract adds the `file.deps` function to the Rego engine.
-func DependencyExtract(res *interfaces.Result) func(*rego.Rego) {
+func DependencyExtract(res *interfaces.Ingested) func(*rego.Rego) {
 	return rego.Function1(
 		&rego.Function{
 			Name: "file.deps",
@@ -820,7 +820,7 @@ func DependencyExtract(res *interfaces.Result) func(*rego.Rego) {
 }
 
 // BaseDependencyExtract adds the `base_file.deps` function to the Rego engine.
-func BaseDependencyExtract(res *interfaces.Result) func(*rego.Rego) {
+func BaseDependencyExtract(res *interfaces.Ingested) func(*rego.Rego) {
 	return rego.Function1(
 		&rego.Function{
 			Name: "base_file.deps",

--- a/internal/engine/eval/rego/lib_test.go
+++ b/internal/engine/eval/rego/lib_test.go
@@ -17,6 +17,7 @@ import (
 
 	engerrors "github.com/mindersec/minder/internal/engine/errors"
 	"github.com/mindersec/minder/internal/engine/eval/rego"
+	"github.com/mindersec/minder/internal/engine/options"
 	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
 	"github.com/mindersec/minder/pkg/engine/v1/interfaces"
 	"github.com/mindersec/minder/pkg/flags"
@@ -43,14 +44,13 @@ allow {
 	file.exists("foo")
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	emptyPol := map[string]any{}
 
 	// Matches
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: nil,
 		Fs:     fs,
 	})
@@ -78,14 +78,14 @@ allow {
     base_file.exists("foo")
 }`,
 		},
-		featureClient,
+		options.WithFlagsClient(featureClient),
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	emptyPol := map[string]any{}
 
 	// Matches
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		BaseFs: fs,
 	})
 	require.NoError(t, err, "could not evaluate")
@@ -108,13 +108,12 @@ allow {
 	file.exists("unexistent")
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	emptyPol := map[string]any{}
 
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: nil,
 		Fs:     fs,
 	})
@@ -146,13 +145,12 @@ allow {
 	contents == "bar"
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	emptyPol := map[string]any{}
 
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: nil,
 		Fs:     fs,
 	})
@@ -184,13 +182,12 @@ allow {
 	contents == "bar"
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	emptyPol := map[string]any{}
 
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: nil,
 		Fs:     fs,
 	})
@@ -215,13 +212,12 @@ allow {
 	is_null(files)
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	emptyPol := map[string]any{}
 
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: nil,
 		Fs:     fs,
 	})
@@ -248,13 +244,12 @@ allow {
 	count(files) == 0
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	emptyPol := map[string]any{}
 
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: nil,
 		Fs:     fs,
 	})
@@ -286,13 +281,12 @@ allow {
 	files[0] == "foo/bar"
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	emptyPol := map[string]any{}
 
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: nil,
 		Fs:     fs,
 	})
@@ -324,13 +318,12 @@ allow {
 	files[0] == "foo/bar"
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	emptyPol := map[string]any{}
 
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: nil,
 		Fs:     fs,
 	})
@@ -365,13 +358,12 @@ allow {
 	count(files) == 3
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	emptyPol := map[string]any{}
 
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: nil,
 		Fs:     fs,
 	})
@@ -409,13 +401,12 @@ allow {
 	count(files) == 3
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	emptyPol := map[string]any{}
 
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: nil,
 		Fs:     fs,
 	})
@@ -448,13 +439,12 @@ allow {
 	count(files) == 1
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	emptyPol := map[string]any{}
 
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: nil,
 		Fs:     fs,
 	})
@@ -546,13 +536,12 @@ allow {
 	actions == expected_set
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	emptyPol := map[string]any{}
 
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: nil,
 		Fs:     fs,
 	})
@@ -583,13 +572,12 @@ allow {
 	actions == expected_set
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	emptyPol := map[string]any{}
 
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: nil,
 		Fs:     fs,
 	})
@@ -619,13 +607,12 @@ allow {
 	count(files) == 1
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	emptyPol := map[string]any{}
 
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: nil,
 		Fs:     fs,
 	})
@@ -666,13 +653,12 @@ allow {
 	count(files) == 3
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	emptyPol := map[string]any{}
 
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: nil,
 		Fs:     fs,
 	})
@@ -703,13 +689,12 @@ allow {
 	htype == "text/plain; charset=utf-8"
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	emptyPol := map[string]any{}
 
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: nil,
 		Fs:     fs,
 	})
@@ -741,13 +726,12 @@ allow {
 	htype == "application/octet-stream"
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	emptyPol := map[string]any{}
 
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: nil,
 		Fs:     fs,
 	})
@@ -792,13 +776,12 @@ allow {
 	count(files) == 7
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	emptyPol := map[string]any{}
 
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: nil,
 		Fs:     fs,
 	})
@@ -848,7 +831,7 @@ violations contains {"msg": sprintf("Expected: %s", [input.profile.expected])} i
 violations contains {"msg": sprintf("Got     : %s", [encoded])} if tarball != expectedTar
 `,
 		},
-		featureClient,
+		options.WithFlagsClient(featureClient),
 	)
 	require.NoError(t, err, "could not create evaluator")
 
@@ -857,7 +840,7 @@ violations contains {"msg": sprintf("Got     : %s", [encoded])} if tarball != ex
 		"expected": base64.StdEncoding.EncodeToString(expectedTarball),
 	}
 
-	_, err = e.Eval(context.Background(), policy, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), policy, nil, &interfaces.Ingested{
 		Object: nil,
 		Fs:     fs,
 	})
@@ -1002,14 +985,13 @@ allow {
 					Type: rego.DenyByDefaultEvaluationType.String(),
 					Def:  regoCode,
 				},
-				nil,
 			)
 			require.NoError(t, err, "could not create evaluator")
 
 			emptyPol := map[string]any{}
 
 			var evalErr *engerrors.EvaluationError
-			_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+			_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 				Object: nil,
 				Fs:     fs,
 			})
@@ -1108,11 +1090,10 @@ allow {
 					Type: rego.DenyByDefaultEvaluationType.String(),
 					Def:  regoCode,
 				},
-				nil,
 			)
 			require.NoError(t, err, "could not create evaluator")
 
-			_, err = e.Eval(context.Background(), map[string]any{}, nil, &interfaces.Result{})
+			_, err = e.Eval(context.Background(), map[string]any{}, nil, &interfaces.Ingested{})
 
 			if s.wantErr {
 				require.Error(t, err)
@@ -1182,12 +1163,11 @@ allow {
 					Type: rego.DenyByDefaultEvaluationType.String(),
 					Def:  regoCode,
 				},
-				nil,
 			)
 
 			require.NoError(t, err, "could not create evaluator")
 
-			_, err = e.Eval(context.Background(), map[string]any{}, nil, &interfaces.Result{})
+			_, err = e.Eval(context.Background(), map[string]any{}, nil, &interfaces.Ingested{})
 
 			if s.wantErr {
 				require.Error(t, err)
@@ -1276,7 +1256,7 @@ allow if {
 }
 `,
 		},
-		featureClient,
+		options.WithFlagsClient(featureClient),
 	)
 	require.NoError(t, err, "could not create evaluator")
 
@@ -1289,7 +1269,7 @@ allow if {
 				"expected": tc.expectedDeps,
 			}
 
-			result, err := e.Eval(context.Background(), policy, nil, &interfaces.Result{
+			result, err := e.Eval(context.Background(), policy, nil, &interfaces.Ingested{
 				Fs: fs,
 			})
 

--- a/internal/engine/eval/rego/rego_test.go
+++ b/internal/engine/eval/rego/rego_test.go
@@ -41,14 +41,13 @@ allow {
 	input.ingested.data == "foo"
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	emptyPol := map[string]any{}
 
 	// Matches
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: map[string]any{
 			"data": "foo",
 		},
@@ -56,7 +55,7 @@ allow {
 	require.NoError(t, err, "could not evaluate")
 
 	// Doesn't match
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: map[string]any{
 			"data": "bar",
 		},
@@ -84,14 +83,13 @@ skip {
 }
 `,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	emptyPol := map[string]any{}
 
 	// Doesn't match
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: map[string]any{
 			"data": "bar",
 		},
@@ -113,14 +111,13 @@ violations[{"msg": msg}] {
 	msg := "data did not contain foo"
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	emptyPol := map[string]any{}
 
 	// Matches
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: map[string]any{
 			"data": "foo",
 		},
@@ -128,7 +125,7 @@ violations[{"msg": msg}] {
 	require.NoError(t, err, "could not evaluate")
 
 	// Doesn't match
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: map[string]any{
 			"data": "bar",
 		},
@@ -157,13 +154,12 @@ violations[{"msg": msg}] {
 }
 `,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	emptyPol := map[string]any{}
 
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: map[string]any{
 			"data":  "foo",
 			"datum": "bar",
@@ -194,7 +190,6 @@ allow {
 	input.profile.data == input.ingested.data
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
@@ -203,7 +198,7 @@ allow {
 	}
 
 	// Matches
-	_, err = e.Eval(context.Background(), pol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), pol, nil, &interfaces.Ingested{
 		Object: map[string]any{
 			"data": "foo",
 		},
@@ -211,7 +206,7 @@ allow {
 	require.NoError(t, err, "could not evaluate")
 
 	// Doesn't match
-	_, err = e.Eval(context.Background(), pol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), pol, nil, &interfaces.Ingested{
 		Object: map[string]any{
 			"data": "bar",
 		},
@@ -233,7 +228,6 @@ violations[{"msg": msg}] {
 	msg := sprintf("data did not match profile: %s", [input.profile.data])
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
@@ -242,7 +236,7 @@ violations[{"msg": msg}] {
 	}
 
 	// Matches
-	_, err = e.Eval(context.Background(), pol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), pol, nil, &interfaces.Ingested{
 		Object: map[string]any{
 			"data": "foo",
 		},
@@ -250,7 +244,7 @@ violations[{"msg": msg}] {
 	require.NoError(t, err, "could not evaluate")
 
 	// Doesn't match
-	_, err = e.Eval(context.Background(), pol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), pol, nil, &interfaces.Ingested{
 		Object: map[string]any{
 			"data": "bar",
 		},
@@ -298,7 +292,6 @@ func TestConstraintsJSONOutput(t *testing.T) {
 			ViolationFormat: &violationFormat,
 			Def:             jsonPolicyDef,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
@@ -306,7 +299,7 @@ func TestConstraintsJSONOutput(t *testing.T) {
 		"data": []string{"foo", "bar"},
 	}
 
-	evalResult, err := e.Eval(context.Background(), pol, nil, &interfaces.Result{
+	evalResult, err := e.Eval(context.Background(), pol, nil, &interfaces.Ingested{
 		Object: map[string]any{
 			"data": []string{"foo", "bar", "baz"},
 		},
@@ -349,7 +342,6 @@ violations[{"msg": msg}] {
 	msg := sprintf("data did not match profile: %s", [input.profile.data])
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
@@ -357,7 +349,7 @@ violations[{"msg": msg}] {
 		"data": "foo",
 	}
 
-	evalResult, err := e.Eval(context.Background(), pol, nil, &interfaces.Result{
+	evalResult, err := e.Eval(context.Background(), pol, nil, &interfaces.Ingested{
 		Object: map[string]any{
 			"data": "bar",
 		},
@@ -385,7 +377,6 @@ func TestOutputTypePassedIntoRule(t *testing.T) {
 			Type: rego.ConstraintsEvaluationType.String(),
 			Def:  jsonPolicyDef,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
@@ -393,7 +384,7 @@ func TestOutputTypePassedIntoRule(t *testing.T) {
 		"data": []string{"one", "two"},
 	}
 
-	_, err = e.Eval(context.Background(), pol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), pol, nil, &interfaces.Ingested{
 		Object: map[string]any{
 			"data": []string{"two", "three"},
 		},
@@ -412,14 +403,14 @@ func TestCantCreateEvaluatorWithInvalidConfig(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := rego.NewRegoEvaluator(nil, nil)
+		_, err := rego.NewRegoEvaluator(nil)
 		require.Error(t, err, "should have failed to create evaluator")
 	})
 
 	t.Run("empty", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := rego.NewRegoEvaluator(&minderv1.RuleType_Definition_Eval_Rego{}, nil)
+		_, err := rego.NewRegoEvaluator(&minderv1.RuleType_Definition_Eval_Rego{})
 		require.Error(t, err, "should have failed to create evaluator")
 	})
 
@@ -430,7 +421,6 @@ func TestCantCreateEvaluatorWithInvalidConfig(t *testing.T) {
 			&minderv1.RuleType_Definition_Eval_Rego{
 				Type: "invalid",
 			},
-			nil,
 		)
 		require.Error(t, err, "should have failed to create evaluator")
 	})
@@ -449,12 +439,11 @@ package minder
 
 violations[{"msg": msg}] {`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	_, err = e.Eval(context.Background(), map[string]any{}, nil,
-		&interfaces.Result{Object: map[string]any{}})
+		&interfaces.Ingested{Object: map[string]any{}})
 	assert.Error(t, err, "should have failed to evaluate")
 }
 
@@ -474,12 +463,11 @@ violations[{"msg": msg}] {
 	msg := "data did not contain foo"
 }`,
 		},
-		nil,
 	)
 	require.NoError(t, err, "could not create evaluator")
 
 	_, err = e.Eval(context.Background(), map[string]any{}, nil,
-		&interfaces.Result{Object: map[string]any{}})
+		&interfaces.Ingested{Object: map[string]any{}})
 	assert.Error(t, err, "should have failed to evaluate")
 }
 
@@ -514,7 +502,6 @@ allow {
 	minder.datasource.fake.source({"datasourcetest": input.ingested.data}) == "foo"
 }`,
 		},
-		nil,
 		options.WithDataSources(fdsr),
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -523,7 +510,7 @@ allow {
 
 	// Matches
 	fdsf.EXPECT().Call(gomock.Any(), gomock.Any(), gomock.Any()).Return("foo", nil)
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: map[string]any{
 			"data": "foo",
 		},
@@ -532,7 +519,7 @@ allow {
 
 	// Doesn't match
 	fdsf.EXPECT().Call(gomock.Any(), gomock.Any(), gomock.Any()).Return("bar", nil)
-	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Result{
+	_, err = e.Eval(context.Background(), emptyPol, nil, &interfaces.Ingested{
 		Object: map[string]any{
 			"data": "bar",
 		},

--- a/internal/engine/eval/trusty/trusty.go
+++ b/internal/engine/eval/trusty/trusty.go
@@ -85,7 +85,7 @@ func (e *Evaluator) Eval(
 	ctx context.Context,
 	pol map[string]any,
 	_ protoreflect.ProtoMessage,
-	res *interfaces.Result,
+	res *interfaces.Ingested,
 ) (*interfaces.EvaluationResult, error) {
 	// Extract the dependency list from the PR
 	prDependencies, err := readPullRequestDependencies(res)
@@ -168,7 +168,7 @@ func getEcosystemConfig(
 }
 
 // readPullRequestDependencies returns the dependencies found in theingestion results
-func readPullRequestDependencies(res *interfaces.Result) (*pbinternal.PrDependencies, error) {
+func readPullRequestDependencies(res *interfaces.Ingested) (*pbinternal.PrDependencies, error) {
 	prdeps, ok := res.Object.(*pbinternal.PrDependencies)
 	if !ok {
 		return nil, fmt.Errorf("object type incompatible with the Trusty evaluator")

--- a/internal/engine/eval/trusty/trusty_test.go
+++ b/internal/engine/eval/trusty/trusty_test.go
@@ -162,11 +162,11 @@ func TestReadPullRequestDependencies(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
 		name    string
-		sut     *interfaces.Result
+		sut     *interfaces.Ingested
 		mustErr bool
 	}{
-		{name: "normal", sut: &interfaces.Result{Object: &pbinternal.PrDependencies{}}, mustErr: false},
-		{name: "invalid-object", sut: &interfaces.Result{Object: context.Background()}, mustErr: true},
+		{name: "normal", sut: &interfaces.Ingested{Object: &pbinternal.PrDependencies{}}, mustErr: false},
+		{name: "invalid-object", sut: &interfaces.Ingested{Object: context.Background()}, mustErr: true},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/engine/eval/vulncheck/vulncheck.go
+++ b/internal/engine/eval/vulncheck/vulncheck.go
@@ -92,7 +92,8 @@ func (e *Evaluator) Eval(
 // getVulnerableDependencies returns a slice containing vulnerable dependencies.
 // TODO: it would be nice if we could express this in rego over
 // `input.ingested.deps[_].dep`, rather than building this in to core.
-func (e *Evaluator) getVulnerableDependencies(ctx context.Context, pol map[string]any, res *interfaces.Ingested) ([]string, error) {
+func (e *Evaluator) getVulnerableDependencies(
+	ctx context.Context, pol map[string]any, res *interfaces.Ingested) ([]string, error) {
 	var vulnerablePackages []string
 
 	prdeps, ok := res.Object.(*pbinternal.PrDependencies)

--- a/internal/engine/eval/vulncheck/vulncheck.go
+++ b/internal/engine/eval/vulncheck/vulncheck.go
@@ -70,7 +70,7 @@ func (e *Evaluator) Eval(
 	ctx context.Context,
 	pol map[string]any,
 	_ protoreflect.ProtoMessage,
-	res *interfaces.Result,
+	res *interfaces.Ingested,
 ) (*interfaces.EvaluationResult, error) {
 	vulnerablePackages, err := e.getVulnerableDependencies(ctx, pol, res)
 	if err != nil {
@@ -92,7 +92,7 @@ func (e *Evaluator) Eval(
 // getVulnerableDependencies returns a slice containing vulnerable dependencies.
 // TODO: it would be nice if we could express this in rego over
 // `input.ingested.deps[_].dep`, rather than building this in to core.
-func (e *Evaluator) getVulnerableDependencies(ctx context.Context, pol map[string]any, res *interfaces.Result) ([]string, error) {
+func (e *Evaluator) getVulnerableDependencies(ctx context.Context, pol map[string]any, res *interfaces.Ingested) ([]string, error) {
 	var vulnerablePackages []string
 
 	prdeps, ok := res.Object.(*pbinternal.PrDependencies)

--- a/internal/engine/ingestcache/cache_test.go
+++ b/internal/engine/ingestcache/cache_test.go
@@ -115,7 +115,7 @@ func TestCache(t *testing.T) {
 			_, ok := cache.Get(tt.args.in0, tt.args.in1, tt.args.in2)
 			require.False(t, ok, "cache should be empty")
 
-			res := &interfaces.Result{
+			res := &interfaces.Ingested{
 				Object: map[string]any{
 					"foo": "bar",
 				},
@@ -139,7 +139,7 @@ func TestCache(t *testing.T) {
 			_, ok := cache.Get(tt.args.in0, tt.args.in1, tt.args.in2)
 			require.False(t, ok, "cache should be empty")
 
-			res := &interfaces.Result{
+			res := &interfaces.Ingested{
 				Object: map[string]any{
 					"foo": "bar",
 				},

--- a/internal/engine/ingestcache/ingestcache.go
+++ b/internal/engine/ingestcache/ingestcache.go
@@ -22,13 +22,13 @@ var ErrBuildingCacheKey = errors.New("error building cache key")
 
 type cache struct {
 	// cache is the actual cache
-	cache *xsync.MapOf[string, *interfaces.Result]
+	cache *xsync.MapOf[string, *interfaces.Ingested]
 }
 
 // NewCache returns a new cache
 func NewCache() Cache {
 	return &cache{
-		cache: xsync.NewMapOf[string, *interfaces.Result](),
+		cache: xsync.NewMapOf[string, *interfaces.Ingested](),
 	}
 }
 
@@ -37,7 +37,7 @@ func (c *cache) Get(
 	ingester interfaces.Ingester,
 	entity protoreflect.ProtoMessage,
 	params map[string]any,
-) (*interfaces.Result, bool) {
+) (*interfaces.Ingested, bool) {
 	key, err := buildCacheKey(ingester, entity, params)
 	if err != nil {
 		// TODO we might want to log this
@@ -53,7 +53,7 @@ func (c *cache) Set(
 	ingester interfaces.Ingester,
 	entity protoreflect.ProtoMessage,
 	params map[string]any,
-	result *interfaces.Result,
+	result *interfaces.Ingested,
 ) {
 	key, err := buildCacheKey(ingester, entity, params)
 	if err != nil {

--- a/internal/engine/ingestcache/interface.go
+++ b/internal/engine/ingestcache/interface.go
@@ -13,6 +13,6 @@ import (
 
 // Cache is the interface for the ingest cache.
 type Cache interface {
-	Get(ingester interfaces.Ingester, entity protoreflect.ProtoMessage, params map[string]any) (*interfaces.Result, bool)
-	Set(ingester interfaces.Ingester, entity protoreflect.ProtoMessage, params map[string]any, result *interfaces.Result)
+	Get(ingester interfaces.Ingester, entity protoreflect.ProtoMessage, params map[string]any) (*interfaces.Ingested, bool)
+	Set(ingester interfaces.Ingester, entity protoreflect.ProtoMessage, params map[string]any, result *interfaces.Ingested)
 }

--- a/internal/engine/ingestcache/noop.go
+++ b/internal/engine/ingestcache/noop.go
@@ -23,7 +23,7 @@ func (*NoopCache) Get(
 	_ interfaces.Ingester,
 	_ protoreflect.ProtoMessage,
 	_ map[string]any,
-) (*interfaces.Result, bool) {
+) (*interfaces.Ingested, bool) {
 	return nil, false
 }
 
@@ -32,6 +32,6 @@ func (*NoopCache) Set(
 	_ interfaces.Ingester,
 	_ protoreflect.ProtoMessage,
 	_ map[string]any,
-	_ *interfaces.Result,
+	_ *interfaces.Ingested,
 ) {
 }

--- a/internal/engine/ingester/artifact/artifact.go
+++ b/internal/engine/ingester/artifact/artifact.go
@@ -84,7 +84,7 @@ func (i *Ingest) Ingest(
 	ctx context.Context,
 	ent proto.Message,
 	params map[string]any,
-) (*interfaces.Result, error) {
+) (*interfaces.Ingested, error) {
 	cfg, err := configFromParams(params)
 	if err != nil {
 		return nil, err
@@ -102,7 +102,7 @@ func (i *Ingest) Ingest(
 		return nil, err
 	}
 
-	return &interfaces.Result{
+	return &interfaces.Ingested{
 		Object: applicable,
 		// We would ideally return an artifact's digest here, but
 		// the current state of the artifact ingester is actually evaluating

--- a/internal/engine/ingester/builtin/builtin.go
+++ b/internal/engine/ingester/builtin/builtin.go
@@ -62,7 +62,7 @@ func (idi *RuleDataIngest) GetConfig() protoreflect.ProtoMessage {
 
 // Ingest calls the builtin method and populates the data to be returned
 func (idi *RuleDataIngest) Ingest(
-	ctx context.Context, ent protoreflect.ProtoMessage, params map[string]any) (*interfaces.Result, error) {
+	ctx context.Context, ent protoreflect.ProtoMessage, params map[string]any) (*interfaces.Ingested, error) {
 	method, err := idi.ruleMethods.GetMethod(idi.method)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get method: %w", err)
@@ -99,7 +99,7 @@ func (idi *RuleDataIngest) Ingest(
 		return nil, fmt.Errorf("cannot unmarshal json: %w", err)
 	}
 
-	return &interfaces.Result{
+	return &interfaces.Ingested{
 		Object:     resultObj,
 		Checkpoint: checkpoints.NewCheckpointV1Now(),
 	}, nil

--- a/internal/engine/ingester/deps/deps.go
+++ b/internal/engine/ingester/deps/deps.go
@@ -90,7 +90,7 @@ func (gi *Deps) GetConfig() protoreflect.ProtoMessage {
 
 // Ingest does the actual data ingestion for a rule type by cloning a git repo,
 // and scanning it for dependencies with a dependency extractor
-func (gi *Deps) Ingest(ctx context.Context, ent protoreflect.ProtoMessage, params map[string]any) (*interfaces.Result, error) {
+func (gi *Deps) Ingest(ctx context.Context, ent protoreflect.ProtoMessage, params map[string]any) (*interfaces.Ingested, error) {
 	switch entity := ent.(type) {
 	case *pb.Repository:
 		return gi.ingestRepository(ctx, entity, params)
@@ -101,7 +101,7 @@ func (gi *Deps) Ingest(ctx context.Context, ent protoreflect.ProtoMessage, param
 	}
 }
 
-func (gi *Deps) ingestRepository(ctx context.Context, repo *pb.Repository, params map[string]any) (*interfaces.Result, error) {
+func (gi *Deps) ingestRepository(ctx context.Context, repo *pb.Repository, params map[string]any) (*interfaces.Ingested, error) {
 	var logger = zerolog.Ctx(ctx)
 	// the branch is left unset since we want to auto-discover it
 	// in case it's not explicitly set
@@ -130,7 +130,7 @@ func (gi *Deps) ingestRepository(ctx context.Context, repo *pb.Repository, param
 		WithBranch(branch).
 		WithCommitHash(hsh.String())
 
-	return &interfaces.Result{
+	return &interfaces.Ingested{
 		Object: map[string]any{
 			"node_list": deps,
 		},
@@ -232,7 +232,7 @@ func filterNodes(base []*sbom.Node, updated []*sbom.Node, compare func(*sbom.Nod
 }
 
 func (gi *Deps) ingestPullRequest(
-	ctx context.Context, pr *pbinternal.PullRequest, params map[string]any) (*interfaces.Result, error) {
+	ctx context.Context, pr *pbinternal.PullRequest, params map[string]any) (*interfaces.Ingested, error) {
 	userCfg := &PullRequestConfig{
 		// We default to new_and_updated for user convenience.
 		Filter: PullRequestIngestTypeNewAndUpdated,
@@ -274,7 +274,7 @@ func (gi *Deps) ingestPullRequest(
 		WithBranch(pr.GetTargetRef()).
 		WithCommitHash(ref.Hash().String())
 
-	return &interfaces.Result{
+	return &interfaces.Ingested{
 		Object: map[string]any{
 			"node_list": targetDeps,
 		},

--- a/internal/engine/ingester/diff/diff.go
+++ b/internal/engine/ingester/diff/diff.go
@@ -83,7 +83,7 @@ func (di *Diff) Ingest(
 	ctx context.Context,
 	ent protoreflect.ProtoMessage,
 	_ map[string]any,
-) (*interfaces.Result, error) {
+) (*interfaces.Ingested, error) {
 	pr, ok := ent.(*pbinternal.PullRequest)
 	if !ok {
 		return nil, fmt.Errorf("entity is not a pull request")
@@ -111,7 +111,7 @@ func (di *Diff) Ingest(
 	}
 }
 
-func (di *Diff) getDepTypeDiff(ctx context.Context, prNumber int, pr *pbinternal.PullRequest) (*interfaces.Result, error) {
+func (di *Diff) getDepTypeDiff(ctx context.Context, prNumber int, pr *pbinternal.PullRequest) (*interfaces.Ingested, error) {
 	deps := pbinternal.PrDependencies{Pr: pr}
 	page := 0
 
@@ -136,10 +136,10 @@ func (di *Diff) getDepTypeDiff(ctx context.Context, prNumber int, pr *pbinternal
 		page = resp.NextPage
 	}
 
-	return &interfaces.Result{Object: &deps, Checkpoint: checkpoints.NewCheckpointV1Now()}, nil
+	return &interfaces.Ingested{Object: &deps, Checkpoint: checkpoints.NewCheckpointV1Now()}, nil
 }
 
-func (di *Diff) getFullTypeDiff(ctx context.Context, prNumber int, pr *pbinternal.PullRequest) (*interfaces.Result, error) {
+func (di *Diff) getFullTypeDiff(ctx context.Context, prNumber int, pr *pbinternal.PullRequest) (*interfaces.Ingested, error) {
 	diff := &pbinternal.PrContents{Pr: pr}
 	page := 0
 
@@ -164,7 +164,7 @@ func (di *Diff) getFullTypeDiff(ctx context.Context, prNumber int, pr *pbinterna
 		page = resp.NextPage
 	}
 
-	return &interfaces.Result{Object: diff, Checkpoint: checkpoints.NewCheckpointV1Now()}, nil
+	return &interfaces.Ingested{Object: diff, Checkpoint: checkpoints.NewCheckpointV1Now()}, nil
 }
 
 func (di *Diff) ingestFileForDepDiff(
@@ -196,7 +196,7 @@ func (di *Diff) ingestFileForDepDiff(
 	return batchCtxDeps, nil
 }
 
-func (di *Diff) getScalibrTypeDiff(ctx context.Context, _ int, pr *pbinternal.PullRequest) (*interfaces.Result, error) {
+func (di *Diff) getScalibrTypeDiff(ctx context.Context, _ int, pr *pbinternal.PullRequest) (*interfaces.Ingested, error) {
 	deps := pbinternal.PrDependencies{Pr: pr}
 
 	// TODO: we should be able to just fetch the additional commits between base and target.
@@ -230,7 +230,7 @@ func (di *Diff) getScalibrTypeDiff(ctx context.Context, _ int, pr *pbinternal.Pu
 		}
 	}
 
-	return &interfaces.Result{Object: &deps, Checkpoint: checkpoints.NewCheckpointV1Now()}, nil
+	return &interfaces.Ingested{Object: &deps, Checkpoint: checkpoints.NewCheckpointV1Now()}, nil
 }
 
 func inventorySorter(a *extractor.Inventory, b *extractor.Inventory) int {

--- a/internal/engine/ingester/git/git.go
+++ b/internal/engine/ingester/git/git.go
@@ -63,7 +63,7 @@ func (gi *Git) GetConfig() protoreflect.ProtoMessage {
 }
 
 // Ingest does the actual data ingestion for a rule type by cloning a git repo
-func (gi *Git) Ingest(ctx context.Context, ent protoreflect.ProtoMessage, params map[string]any) (*interfaces.Result, error) {
+func (gi *Git) Ingest(ctx context.Context, ent protoreflect.ProtoMessage, params map[string]any) (*interfaces.Ingested, error) {
 	switch entity := ent.(type) {
 	case *pb.Repository:
 		return gi.ingestRepository(ctx, entity, params)
@@ -74,7 +74,7 @@ func (gi *Git) Ingest(ctx context.Context, ent protoreflect.ProtoMessage, params
 	}
 }
 
-func (gi *Git) ingestRepository(ctx context.Context, repo *pb.Repository, params map[string]any) (*interfaces.Result, error) {
+func (gi *Git) ingestRepository(ctx context.Context, repo *pb.Repository, params map[string]any) (*interfaces.Ingested, error) {
 	userCfg := &IngesterConfig{}
 	if err := mapstructure.Decode(params, userCfg); err != nil {
 		return nil, fmt.Errorf("failed to read git ingester configuration from params: %w", err)
@@ -97,7 +97,7 @@ func (gi *Git) ingestRepository(ctx context.Context, repo *pb.Repository, params
 		WithBranch(branch).
 		WithCommitHash(hsh.String())
 
-	return &interfaces.Result{
+	return &interfaces.Ingested{
 		Object:     nil,
 		Fs:         fs,
 		Storer:     storer,
@@ -106,7 +106,7 @@ func (gi *Git) ingestRepository(ctx context.Context, repo *pb.Repository, params
 }
 
 func (gi *Git) ingestPullRequest(
-	ctx context.Context, ent *pbinternal.PullRequest, params map[string]any) (*interfaces.Result, error) {
+	ctx context.Context, ent *pbinternal.PullRequest, params map[string]any) (*interfaces.Ingested, error) {
 	// TODO: we don't actually have any configuration here.  Do we need to read the configuration?
 	userCfg := &IngesterConfig{}
 	if err := mapstructure.Decode(params, userCfg); err != nil {
@@ -131,7 +131,7 @@ func (gi *Git) ingestPullRequest(
 
 	checkpoint := checkpoints.NewCheckpointV1Now().WithBranch(ent.GetTargetRef()).WithCommitHash(head.Hash().String())
 
-	return &interfaces.Result{
+	return &interfaces.Ingested{
 		Object:     nil,
 		Fs:         targetFs,
 		Storer:     storer,

--- a/internal/engine/ingester/rest/rest.go
+++ b/internal/engine/ingester/rest/rest.go
@@ -107,7 +107,7 @@ func (rdi *Ingestor) GetConfig() protoreflect.ProtoMessage {
 // Ingest calls the REST endpoint and returns the data
 func (rdi *Ingestor) Ingest(
 	ctx context.Context, ent protoreflect.ProtoMessage, params map[string]any,
-) (*interfaces.Result, error) {
+) (*interfaces.Ingested, error) {
 	retp := &EndpointTemplateParams{
 		Entity: ent,
 		Params: params,
@@ -145,7 +145,7 @@ func (rdi *Ingestor) Ingest(
 		return nil, fmt.Errorf("cannot parse body: %w", err)
 	}
 
-	return &interfaces.Result{
+	return &interfaces.Ingested{
 		Object:     data,
 		Checkpoint: checkpoints.NewCheckpointV1Now().WithHTTP(endpoint, rdi.method),
 	}, nil

--- a/internal/engine/ingester/rest/rest_test.go
+++ b/internal/engine/ingester/rest/rest_test.go
@@ -176,7 +176,7 @@ func TestRestIngest(t *testing.T) {
 		newIngArgs  newRestIngestArgs
 		ingArgs     ingestArgs
 		testHandler http.HandlerFunc
-		ingResultFn func() *interfaces.Result
+		ingResultFn func() *interfaces.Ingested
 		wantErr     bool
 	}{
 		{
@@ -205,13 +205,13 @@ func TestRestIngest(t *testing.T) {
 				assert.NoError(t, err, "unexpected error writing response")
 				writer.WriteHeader(http.StatusOK)
 			},
-			ingResultFn: func() *interfaces.Result {
+			ingResultFn: func() *interfaces.Ingested {
 				var jReply any
 				if err := json.NewDecoder(strings.NewReader(validProtectionReply)).Decode(&jReply); err != nil {
 					return nil
 				}
 
-				return &interfaces.Result{
+				return &interfaces.Ingested{
 					Object: jReply,
 				}
 			},
@@ -247,13 +247,13 @@ func TestRestIngest(t *testing.T) {
 
 				writer.WriteHeader(http.StatusNotFound)
 			},
-			ingResultFn: func() *interfaces.Result {
+			ingResultFn: func() *interfaces.Ingested {
 				var jReply any
 				if err := json.NewDecoder(strings.NewReader(notFoundReply)).Decode(&jReply); err != nil {
 					return nil
 				}
 
-				return &interfaces.Result{
+				return &interfaces.Ingested{
 					Object: jReply,
 				}
 			},

--- a/internal/engine/interfaces/interface.go
+++ b/internal/engine/interfaces/interface.go
@@ -48,7 +48,7 @@ const (
 // a repo and most profiles are expecting a repo, the RepoID parameter is mandatory. For entities
 // other than artifacts, the ArtifactID should be 0 that is translated to NULL in the database.
 type EvalStatusParams struct {
-	Result           *interfaces.Result
+	Result           *interfaces.Ingested
 	Profile          *models.ProfileAggregate
 	Rule             *models.RuleInstance
 	ProjectID        uuid.UUID
@@ -139,12 +139,12 @@ func (e *EvalStatusParams) GetProfile() *models.ProfileAggregate {
 }
 
 // SetIngestResult sets the result of the ingestion for use later on in the actions
-func (e *EvalStatusParams) SetIngestResult(res *interfaces.Result) {
+func (e *EvalStatusParams) SetIngestResult(res *interfaces.Ingested) {
 	e.Result = res
 }
 
 // GetIngestResult returns the result of the ingestion, if any
-func (e *EvalStatusParams) GetIngestResult() *interfaces.Result {
+func (e *EvalStatusParams) GetIngestResult() *interfaces.Ingested {
 	return e.Result
 }
 
@@ -165,7 +165,7 @@ func (e *EvalStatusParams) DecorateLogger(l zerolog.Logger) zerolog.Logger {
 // EvalParamsReader is the interface used for a rule type evaluator
 type EvalParamsReader interface {
 	GetRule() *models.RuleInstance
-	GetIngestResult() *interfaces.Result
+	GetIngestResult() *interfaces.Ingested
 }
 
 // ActionsParams is the interface used for processing a rule type action

--- a/internal/engine/rtengine/cache.go
+++ b/internal/engine/rtengine/cache.go
@@ -153,10 +153,10 @@ func cacheRuleEngine(
 		return nil, fmt.Errorf("error building data source registry: %w", err)
 	}
 
-	opts = append(opts, eoptions.WithDataSources(dsreg))
+	opts = append(opts, eoptions.WithDataSources(dsreg), eoptions.WithFlagsClient(featureFlags))
 
 	// Create the rule type engine
-	ruleEngine, err := rtengine2.NewRuleTypeEngine(ctx, pbRuleType, provider, featureFlags, opts...)
+	ruleEngine, err := rtengine2.NewRuleTypeEngine(ctx, pbRuleType, provider, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("error creating rule type engine: %w", err)
 	}

--- a/pkg/datasources/v1/datasources.go
+++ b/pkg/datasources/v1/datasources.go
@@ -43,7 +43,7 @@ type DataSourceFuncDef interface {
 	// It is the responsibility of the data source implementation to handle the call.
 	// It is also the responsibility of the caller to validate the arguments
 	// before calling the function.
-	Call(ctx context.Context, ingest *interfaces.Result, args any) (any, error)
+	Call(ctx context.Context, ingest *interfaces.Ingested, args any) (any, error)
 	// GetArgsSchema returns the schema of the arguments.
 	GetArgsSchema() *structpb.Struct
 }
@@ -63,5 +63,5 @@ type ContextKey struct {
 
 // Context encapsulates the context passed to all context function calls
 type Context struct {
-	Ingest *interfaces.Result
+	Ingest *interfaces.Ingested
 }

--- a/pkg/datasources/v1/mock/datasources.go
+++ b/pkg/datasources/v1/mock/datasources.go
@@ -44,7 +44,7 @@ func (m *MockDataSourceFuncDef) EXPECT() *MockDataSourceFuncDefMockRecorder {
 }
 
 // Call mocks base method.
-func (m *MockDataSourceFuncDef) Call(ctx context.Context, ingest *interfaces.Result, args any) (any, error) {
+func (m *MockDataSourceFuncDef) Call(ctx context.Context, ingest *interfaces.Ingested, args any) (any, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Call", ctx, ingest, args)
 	ret0, _ := ret[0].(any)

--- a/pkg/engine/v1/interfaces/interfaces.go
+++ b/pkg/engine/v1/interfaces/interfaces.go
@@ -17,7 +17,7 @@ import (
 // Ingester is the interface for a rule type ingester
 type Ingester interface {
 	// Ingest does the actual data ingestion for a rule type
-	Ingest(ctx context.Context, ent protoreflect.ProtoMessage, params map[string]any) (*Result, error)
+	Ingest(ctx context.Context, ent protoreflect.ProtoMessage, params map[string]any) (*Ingested, error)
 	// GetType returns the type of the ingester
 	GetType() string
 	// GetConfig returns the config for the ingester
@@ -26,11 +26,11 @@ type Ingester interface {
 
 // Evaluator is the interface for a rule type evaluator
 type Evaluator interface {
-	Eval(ctx context.Context, profile map[string]any, entity protoreflect.ProtoMessage, res *Result) (*EvaluationResult, error)
+	Eval(ctx context.Context, profile map[string]any, entity protoreflect.ProtoMessage, data *Ingested) (*EvaluationResult, error)
 }
 
-// Result is the result of an ingester
-type Result struct {
+// Ingested is the result of an ingester
+type Ingested struct {
 	// Object is the object that was ingested. Normally comes from an external
 	// system like an HTTP server.
 	Object any
@@ -59,7 +59,7 @@ type EvaluationResult struct {
 }
 
 // GetCheckpoint returns the checkpoint of the result
-func (r *Result) GetCheckpoint() *checkpoints.CheckpointEnvelopeV1 {
+func (r *Ingested) GetCheckpoint() *checkpoints.CheckpointEnvelopeV1 {
 	if r == nil {
 		return nil
 	}
@@ -69,5 +69,5 @@ func (r *Result) GetCheckpoint() *checkpoints.CheckpointEnvelopeV1 {
 
 // ResultSink sets the result of an ingestion
 type ResultSink interface {
-	SetIngestResult(*Result)
+	SetIngestResult(*Ingested)
 }

--- a/pkg/engine/v1/rtengine/engine_test.go
+++ b/pkg/engine/v1/rtengine/engine_test.go
@@ -92,7 +92,7 @@ allow {
 			}
 
 			tk := tkv1.NewTestKit(tkv1.WithGitDir(tdir))
-			rte, err := NewRuleTypeEngine(ctx, tt.ruleType, tk, nil)
+			rte, err := NewRuleTypeEngine(ctx, tt.ruleType, tk)
 			require.NoError(t, err, "NewRuleTypeEngine() failed")
 
 			// Override ingester. This is needed for the test.

--- a/pkg/testkit/v1/testkit_ingest.go
+++ b/pkg/testkit/v1/testkit_ingest.go
@@ -25,7 +25,7 @@ var _ interfaces.Ingester = &TestKit{}
 // Ingest is a stub implementation of the ingester
 func (tk *TestKit) Ingest(
 	ctx context.Context, ent protoreflect.ProtoMessage, params map[string]any,
-) (*interfaces.Result, error) {
+) (*interfaces.Ingested, error) {
 	if tk.ingestType == git.GitRuleDataIngestType {
 		return tk.fakeGit(ctx, ent, params)
 	}
@@ -49,9 +49,9 @@ func (*TestKit) GetConfig() protoreflect.ProtoMessage {
 
 func (tk *TestKit) fakeGit(
 	_ context.Context, _ protoreflect.ProtoMessage, _ map[string]any,
-) (*interfaces.Result, error) {
+) (*interfaces.Ingested, error) {
 	fs := osfs.New(tk.gitDir)
-	return &interfaces.Result{
+	return &interfaces.Ingested{
 		Fs: fs,
 	}, nil
 }

--- a/pkg/testkit/v1/voidresultsink.go
+++ b/pkg/testkit/v1/voidresultsink.go
@@ -14,5 +14,5 @@ func NewVoidResultSink() *VoidResultSink {
 }
 
 // SetIngestResult implements the ResultSink interface
-func (VoidResultSink) SetIngestResult(_ *interfaces.Result) {
+func (VoidResultSink) SetIngestResult(_ *interfaces.Ingested) {
 }


### PR DESCRIPTION
# Summary

I was looking at using `github.com/mindersec/minder/pkg/engine` in Scorecards, and I noticed a few places where the Minder code was more complex than necessary:

* explicitly passing a `flags.Interface` where we already had functional options wired in
* simplify project / organization naming
* I added a rename of `interfaces.Result` to `interfaces.Ingested` because I always think of `Result` as an `EvaluationResult`...

Not addressed: `NewRuleTypeEngine` takes a varargs list of `github.com/mindersec/minder/internal/engine/options`, which can't be instantiated outside the project because they are in the `internal` branch.  This includes DataSources, which seems important.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Checked unit tests for coverage on the changes.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
