### PR TITLE
Avoid overriding default transport with a limited round-tripper in some cases

### DIFF
--- a/internal/engine/eval/rego/http.go
+++ b/internal/engine/eval/rego/http.go
@@ -45,6 +45,7 @@ func LimitedDialer(transport *http.Transport) http.RoundTripper {
 			transport = &http.Transport{}
 		}
 	}
+	transport = transport.Clone()
 	transport.DialContext = publicOnlyDialer(transport.DialContext)
 	return transport
 }


### PR DESCRIPTION
# Summary

I recently found a case where _somehow_ (the path wasn't clear), the OpenFGA client ended up instantiating an `http.DefaultClient` which had the `publicOnlyDialer` installed.  This resulted in the following error message:

```
{"level":"error","request_id":"dcf83d26-8d31-434a-beda-f407bf42eda4","Resource":{"service":"minder.v1.UserService","method":"GetUser"},"login_sha":"----","telemetry":"true","Attributes":{"http.code":"Unknown","http.content-type":["application/grpc"],"http.duration":"1ms","http.forwarded":["10.0.0.1"],"http.user_agent":["minder-cli"],"exception.message":"rpc error: code = Unknown desc = failed to get user dependencies: unable to read authorization tuples: Post \"http://openfga.openfga.svc:8080/stores/ABCD/read\": remote address is not public"},"caller":"github.com/mindersec/minder/internal/logger/logging_interceptor.go:89","Timestamp":1234}
```

This change ensures that `LimitedDialer` will never update the base `http.DefaultClient`

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Automated (unit) tests.  I wasn't able to figure out how this happened, though I was experimenting with DataSources around the same time.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
