### PR TITLE
Support EvalResultOutput in PR templates

### DIFF
--- a/internal/engine/actions/remediate/pull_request/pull_request.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request.go
@@ -130,6 +130,8 @@ type PrTemplateParams struct {
 	Profile map[string]any
 	// Params are the rule instance parameters
 	Params map[string]any
+	// EvalResultOutput is the data output by the rule evaluation engine
+	EvalResultOutput any
 }
 
 // Class returns the action type of the remediation engine
@@ -188,6 +190,10 @@ func (r *Remediator) getParamsForPRRemediation(
 		Entity:  ent,
 		Profile: params.GetRule().Def,
 		Params:  params.GetRule().Params,
+	}
+
+	if params.GetEvalResult() != nil {
+		tmplParams.EvalResultOutput = params.GetEvalResult().Output
 	}
 
 	ingested := params.GetIngestResult()

--- a/internal/engine/actions/remediate/pull_request/pull_request_test.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request_test.go
@@ -107,11 +107,11 @@ func dependabotPrRem() *pb.RuleType_Definition_Remediate_PullRequestRemediation 
 		Contents: []*pb.RuleType_Definition_Remediate_PullRequestRemediation_Content{
 			{
 				Path:    ".github/dependabot.yml",
-				Content: "dependabot config for {{.Profile.package_ecosystem }}",
+				Content: "dependabot config for {{ .EvalResultOutput.ViolationMsg }}",
 			},
 			{
 				Path:    "README.md",
-				Content: "This project uses dependabot",
+				Content: "This project uses dependabot for {{ .Profile.package_ecosystem }}",
 			},
 		},
 	}
@@ -685,6 +685,9 @@ func TestPullRequestRemediate(t *testing.T) {
 					Fs:     testWt.Filesystem,
 					Storer: testrepo.Storer,
 				})
+			evalParams.SetEvalResult(&interfaces2.EvaluationResult{
+				Output: struct{ ViolationMsg string }{ViolationMsg: "gomod"},
+			})
 			retMeta, err := engine.Do(context.Background(),
 				interfaces.ActionCmdOn,
 				tt.remArgs.ent,

--- a/internal/engine/actions/remediate/pull_request/types_content.go
+++ b/internal/engine/actions/remediate/pull_request/types_content.go
@@ -110,6 +110,9 @@ func (ca *contentModification) createFsModEntries(
 		"Params":  params.GetRule().Params,
 		"Profile": params.GetRule().Def,
 	}
+	if params.GetEvalResult() != nil {
+		data["EvalResultOutput"] = params.GetEvalResult().Output
+	}
 	for i, entry := range ca.entries {
 		content := new(bytes.Buffer)
 		path := new(bytes.Buffer)


### PR DESCRIPTION
# Summary

Enables the use of `EvalRequestOutput` in pull_request remediations, particularly bodies and file contents.  
This allows using data collected during rule evaluation to craft file contents (for example, detected 
ecosystems in dependabot.yml updates)

Continues the work in #5204

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation  updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Unit tests and a quick usage test.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
