### PR TITLE
Use current branch when sending pull requests, rather than hard-coding main

### DIFF
--- a/internal/engine/actions/remediate/pull_request/pull_request.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request.go
@@ -42,7 +42,6 @@ const (
 	// if no Mode is specified, create a regular file with 0644 UNIX permissions
 	ghModeNonExecFile = "100644"
 	dflBranchBaseName = "minder"
-	dflBranchTo       = "main"
 )
 
 const (
@@ -365,7 +364,7 @@ func (r *Remediator) runOn(
 			ctx, p.repo.GetOwner(), p.repo.GetName(),
 			p.title, p.body,
 			refspec,
-			dflBranchTo,
+			currHeadName.Short(),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("cannot create pull request: %w, %w", err, enginerr.ErrActionFailed)

--- a/internal/engine/actions/remediate/pull_request/pull_request_test.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request_test.go
@@ -45,8 +45,9 @@ import (
 const (
 	ghApiUrl = "https://api.github.com"
 
-	repoOwner = "stacklok"
-	repoName  = "minder"
+	repoOwner   = "stacklok"
+	repoName    = "minder"
+	dflBranchTo = "main"
 
 	commitTitle = "Add Dependabot configuration for gomod"
 	prBody      = `Adds Dependabot configuration for gomod`
@@ -279,7 +280,7 @@ func mockUpstreamSetup(t *testing.T, postSetupHooks ...hookFunc) (*git.Repositor
 	fs := osfs.New(tmpdir, osfs.WithBoundOS())
 
 	// initialize the repo with a commit or else creating a branch will fail
-	r, err := git.Init(fsStorer, fs)
+	r, err := git.InitWithOptions(fsStorer, fs, git.InitOptions{DefaultBranch: "refs/heads/main"})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Summary

The current `pull_request` action *always* attempts to PR to the `main` branch, whether or not that branch exists.  Instead, we should PR to the same branch being evaluated 
by the git ingest.

Fixes #5629

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Updated unit tests, found that they failed due to the wrong branch name.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.

