### PR TITLE
Re-use embedded postgres instance across tests

### DIFF
--- a/internal/db/embedded/testdb.go
+++ b/internal/db/embedded/testdb.go
@@ -9,12 +9,14 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"sync"
 
 	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres" // nolint
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 
 	"github.com/mindersec/minder/database"
+	"github.com/mindersec/minder/internal/crypto"
 	"github.com/mindersec/minder/internal/db"
 )
 
@@ -22,10 +24,28 @@ import (
 // Pass this to t.Cleanup.
 type CancelFunc func()
 
-// GetFakeStore returns a new embedded Postgres database and a cancel function
-// to clean up the database.
-func GetFakeStore() (db.Store, CancelFunc, error) {
-	cfg := embeddedpostgres.DefaultConfig()
+type sharedPostgres struct {
+	postgres *embeddedpostgres.EmbeddedPostgres
+	cfg      embeddedpostgres.Config
+	inFlight sync.WaitGroup
+	lock     sync.Mutex
+}
+
+var instance sharedPostgres
+
+// ensurePostgres is a one-shot function to set up an embedded Postgres server.
+// Individual tests should use GetFakeStore to get a handle to a unique database
+// table space within the shared server.  Using a shared server allows us to
+// amortize the cost of starting the server across multiple tests.
+func ensurePostgres() (*embeddedpostgres.Config, CancelFunc, error) {
+	instance.lock.Lock()
+	defer instance.lock.Unlock()
+
+	if instance.postgres != nil {
+		return newDBFromShared()
+	}
+
+	instance.cfg = embeddedpostgres.DefaultConfig()
 	port, err := pickUnusedPort()
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to pick a port: %w", err)
@@ -39,18 +59,65 @@ func GetFakeStore() (db.Store, CancelFunc, error) {
 			fmt.Printf("Unable to remove tmpdir %q: %v\n", tmpName, err)
 		}
 	}
-	cfg = cfg.Port(uint32(port)).RuntimePath(tmpName)
+	instance.cfg = instance.cfg.Port(uint32(port)).RuntimePath(tmpName)
 
-	postgres := embeddedpostgres.NewDatabase(cfg)
-	if err := postgres.Start(); err != nil {
+	instance.postgres = embeddedpostgres.NewDatabase(instance.cfg)
+	if err := instance.postgres.Start(); err != nil {
 		return nil, cleanupDir, fmt.Errorf("unable to start postgres: %w", err)
 	}
-	cancel := func() {
-		if err := postgres.Stop(); err != nil {
+	cfg, cancel, err := newDBFromShared()
+	go func() {
+		instance.inFlight.Wait()
+		instance.lock.Lock()
+		defer instance.lock.Unlock()
+		if err := instance.postgres.Stop(); err != nil {
 			fmt.Printf("Unable to stop postgres: %v\n", err)
 		}
 		cleanupDir()
+	}()
+
+	return cfg, cancel, err
+}
+
+// newDBFromShared is a helper function to create a new database in the shared
+// Postgres instance.  It assumes that the instance global is locked.
+func newDBFromShared() (*embeddedpostgres.Config, CancelFunc, error) {
+	sqlDB, err := sql.Open("postgres", instance.cfg.GetConnectionURL()+"?sslmode=disable")
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to open database: %w", err)
 	}
+	// TODO: make this align with test names in some way.
+	dbName, err := crypto.GenerateNonce()
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to generate database name: %w", err)
+	}
+	instance.inFlight.Add(1)
+
+	_, err = sqlDB.Exec(fmt.Sprintf("CREATE DATABASE %q", dbName))
+	if err != nil {
+		instance.inFlight.Done()
+		return nil, nil, fmt.Errorf("unable to create database: %w", err)
+	}
+	cfg := instance.cfg
+	cfg = cfg.Database(dbName)
+	cancel := func() {
+		instance.lock.Lock()
+		defer instance.lock.Unlock()
+		// TODO: do we care about dropping the database?
+		instance.inFlight.Done()
+	}
+	return &cfg, cancel, nil
+}
+
+// GetFakeStore returns a new embedded Postgres database and a cancel function
+// to clean up the database.
+func GetFakeStore() (db.Store, CancelFunc, error) {
+	cfg, cancel, err := ensurePostgres()
+
+	if err != nil {
+		return nil, cancel, fmt.Errorf("unable to start postgres: %w", err)
+	}
+
 	sqlDB, err := sql.Open("postgres", cfg.GetConnectionURL()+"?sslmode=disable")
 	if err != nil {
 		return nil, cancel, fmt.Errorf("unable to open database: %w", err)

--- a/internal/db/embedded/testdb.go
+++ b/internal/db/embedded/testdb.go
@@ -70,7 +70,11 @@ func ensurePostgres() (*embeddedpostgres.Config, CancelFunc, error) {
 		instance.inFlight.Wait()
 		instance.lock.Lock()
 		defer instance.lock.Unlock()
-		if err := instance.postgres.Stop(); err != nil {
+		// Reset state so we can start a new server if needed.
+		old := instance.postgres
+		instance.postgres = nil
+		instance.inFlight = sync.WaitGroup{}
+		if err := old.Stop(); err != nil {
 			fmt.Printf("Unable to stop postgres: %v\n", err)
 		}
 		cleanupDir()


### PR DESCRIPTION
# Summary

Currently, we create a new embedded postgres server for each test which uses it (at least 14 call sites).  Each server needs its own port, and goes through all the postgres initialization steps.

It turns out, we need a separate postgres _database_, but not a separate _server_.  This change re-uses the server (and amortizes server startup), for a substantial reduction in test execution time.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Tested this (with other changes in place) on `./internal/controlplane`, but going to use CI to validate the full pass.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
