### PR TITLE
Add templates for REST and YQ eval

### DIFF
--- a/docs/docs/ref/rule_evaluation_details.md
+++ b/docs/docs/ref/rule_evaluation_details.md
@@ -178,7 +178,7 @@ Remediation actions have access to:
 
 - The `Entity` object representing the resource being evaluated
 - The `Profile` object containing rule parameters and definitions
-- For remediations which create a pull request, output from the rule evaluation
+- For pull request and REST call remediations, output from the rule evaluation
   is available in `EvalResultOutput`.
 
 ### Remediation Types
@@ -232,16 +232,17 @@ Minder supports three remediation actions:
 
    The
    [REST remediation](https://mindersec.github.io/ref/proto#minder-v1-RestType)
-   calls the specified `endpoint` using the defined HTTP `method`, passing a
-   `body` and optional `headers`.
+   calls the specified `endpoint` using the defined HTTP `method`, passing the
+   supplied `body`. Currently, `headers` are not supported.
 
-   Both the endpoint and the body support Go template parameters, with the
+   `endpoint`, `method` and `body` support Go template parameters, with the
    following data:
 
    - `Entity` contains the same entity information available during rule
      evaluation
    - `Profile` contains the profile data supplied in the `def` field
    - `Params` contains the profile data supplied in the `params` field
+   - `EvalResultOutput` contains the output data from the rule evaluation step
 
 3. **GitHub Branch Protection** (`gh_branch_protect`)
 

--- a/internal/engine/actions/remediate/pull_request/pull_request.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request.go
@@ -21,7 +21,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/google/go-github/v63/github"
 	"github.com/rs/zerolog"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/mindersec/minder/internal/db"
 	enginerr "github.com/mindersec/minder/internal/engine/errors"
@@ -152,7 +152,7 @@ func (r *Remediator) GetOnOffState() models.ActionOpt {
 func (r *Remediator) Do(
 	ctx context.Context,
 	cmd interfaces.ActionCmd,
-	ent protoreflect.ProtoMessage,
+	ent proto.Message,
 	params interfaces.ActionsParams,
 	metadata *json.RawMessage,
 ) (json.RawMessage, error) {
@@ -174,7 +174,7 @@ func (r *Remediator) Do(
 
 func (r *Remediator) getParamsForPRRemediation(
 	ctx context.Context,
-	ent protoreflect.ProtoMessage,
+	ent proto.Message,
 	params interfaces.ActionsParams,
 	metadata *json.RawMessage,
 ) (*paramsPR, error) {
@@ -215,7 +215,7 @@ func (r *Remediator) getParamsForPRRemediation(
 		return nil, fmt.Errorf("cannot get modification: %w", err)
 	}
 
-	err = modification.createFsModEntries(ctx, params)
+	err = modification.createFsModEntries(ctx, ent, params)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create PR entries: %w", err)
 	}

--- a/internal/engine/actions/remediate/pull_request/types_actions_replace_tags.go
+++ b/internal/engine/actions/remediate/pull_request/types_actions_replace_tags.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/filemode"
 	"github.com/stacklok/frizbee/pkg/replacer"
 	"github.com/stacklok/frizbee/pkg/utils/config"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/mindersec/minder/internal/engine/interfaces"
 	v1 "github.com/mindersec/minder/pkg/providers/v1"
@@ -52,7 +53,8 @@ func newFrizbeeTagResolveModification(
 	}, nil
 }
 
-func (ftr *frizbeeTagResolveModification) createFsModEntries(ctx context.Context, _ interfaces.ActionsParams) error {
+func (ftr *frizbeeTagResolveModification) createFsModEntries(
+	ctx context.Context, _ proto.Message, _ interfaces.ActionsParams) error {
 	// Create a new Frizbee instance
 	r := replacer.NewGitHubActionsReplacer(&config.Config{GHActions: *ftr.fzcfg}).WithGitHubClient(ftr.ghCli)
 

--- a/internal/engine/actions/remediate/pull_request/types_content.go
+++ b/internal/engine/actions/remediate/pull_request/types_content.go
@@ -9,6 +9,8 @@ import (
 	"context" // #nosec G505 - we're not using sha1 for crypto, only to quickly compare contents
 	"fmt"
 
+	"google.golang.org/protobuf/proto"
+
 	"github.com/mindersec/minder/internal/engine/interfaces"
 	"github.com/mindersec/minder/internal/util"
 	pb "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
@@ -104,9 +106,11 @@ func prConfigToEntries(prCfg *pb.RuleType_Definition_Remediate_PullRequestRemedi
 
 func (ca *contentModification) createFsModEntries(
 	ctx context.Context,
+	ent proto.Message,
 	params interfaces.ActionsParams,
 ) error {
 	data := map[string]interface{}{
+		"Entity":  ent,
 		"Params":  params.GetRule().Params,
 		"Profile": params.GetRule().Def,
 	}

--- a/internal/engine/actions/remediate/pull_request/types_registry.go
+++ b/internal/engine/actions/remediate/pull_request/types_registry.go
@@ -9,6 +9,7 @@ import (
 	"io"
 
 	"github.com/go-git/go-billy/v5"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/mindersec/minder/internal/engine/interfaces"
 	pb "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
@@ -18,7 +19,7 @@ import (
 type fsModifier interface {
 	hash() (string, error)
 	writeSummary(out io.Writer) error
-	createFsModEntries(ctx context.Context, params interfaces.ActionsParams) error
+	createFsModEntries(ctx context.Context, ent proto.Message, params interfaces.ActionsParams) error
 	modifyFs() ([]*fsEntry, error)
 }
 

--- a/internal/engine/actions/remediate/pull_request/types_yq.go
+++ b/internal/engine/actions/remediate/pull_request/types_yq.go
@@ -13,10 +13,14 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/filemode"
 	"github.com/mikefarah/yq/v4/pkg/yqlib"
 	"github.com/rs/zerolog"
+	"google.golang.org/protobuf/proto"
 	gologging "gopkg.in/op/go-logging.v1"
 
 	"github.com/mindersec/minder/internal/engine/interfaces"
+	textutil "github.com/mindersec/minder/internal/util"
 )
+
+// TODO: document the YQ remediation model.
 
 // unfortunately yqlib does seem to be using global variables...
 func init() {
@@ -82,7 +86,19 @@ func newYqExecute(
 	}, nil
 }
 
-func (yq *yqExecute) createFsModEntries(ctx context.Context, _ interfaces.ActionsParams) error {
+// templateParams are the parameters for template expansion for the expression template
+type templateParams struct {
+	// Entity is the metadata for the entity which was evaluated
+	Entity any
+	// Profile is the parameters to be used in the template
+	Profile map[string]any
+	// Params are the rule instance parameters
+	Params map[string]any
+	// EvalResultOutput is the output from the rule evaluation
+	EvalResultOutput any
+}
+
+func (yq *yqExecute) createFsModEntries(ctx context.Context, ent proto.Message, params interfaces.ActionsParams) error {
 	matchingFiles := make([]string, 0)
 	for _, pattern := range yq.config.Patterns {
 		if pattern.Type != string(patternTypeGlob) {
@@ -100,8 +116,30 @@ func (yq *yqExecute) createFsModEntries(ctx context.Context, _ interfaces.Action
 		matchingFiles = append(matchingFiles, patternMatches...)
 	}
 
+	templateData := templateParams{
+		Entity:  ent,
+		Profile: params.GetRule().Def,
+		Params:  params.GetRule().Params,
+	}
+	if params.GetEvalResult() != nil {
+		templateData.EvalResultOutput = params.GetEvalResult().Output
+	}
+
+	expression := ""
+	if yq.config.Expression != "" {
+		expressionBytes := new(bytes.Buffer)
+		expressionTmpl, err := textutil.NewSafeTextTemplate(&yq.config.Expression, "expression")
+		if err != nil {
+			return fmt.Errorf("unable to parse templates in expression: %w", err)
+		}
+		if err := expressionTmpl.Execute(ctx, expressionBytes, templateData, 3000); err != nil {
+			return fmt.Errorf("unable to expand templates in expression: %w", err)
+		}
+		expression = expressionBytes.String()
+	}
+
 	for _, file := range matchingFiles {
-		newContent, err := yq.executeYq(file, yq.config.Expression)
+		newContent, err := yq.executeYq(file, expression)
 		if err != nil {
 			return fmt.Errorf("cannot execute yq: %w", err)
 		}

--- a/internal/engine/actions/remediate/rest/rest.go
+++ b/internal/engine/actions/remediate/rest/rest.go
@@ -6,11 +6,13 @@ package rest
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/google/go-github/v63/github"
 	"github.com/rs/zerolog"
@@ -29,17 +31,20 @@ const (
 	// RemediateType is the type of the REST remediation engine
 	RemediateType = "rest"
 
-	// EndpointBytesLimit is the maximum number of bytes for the endpoint
-	EndpointBytesLimit = 1024
+	// methodBytesLimit is the maximum number of bytes for the HTTP method
+	methodBytesLimit = 10
 
-	// BodyBytesLimit is the maximum number of bytes for the body
-	BodyBytesLimit = 5120
+	// endpointBytesLimit is the maximum number of bytes for the endpoint
+	endpointBytesLimit = 1024
+
+	// bodyBytesLimit is the maximum number of bytes for the body
+	bodyBytesLimit = 5120
 )
 
 // Remediator keeps the status for a rule type that uses REST remediation
 type Remediator struct {
 	actionType       interfaces.ActionType
-	method           string
+	method           *util.SafeTemplate
 	cli              provifv1.REST
 	endpointTemplate *util.SafeTemplate
 	bodyTemplate     *util.SafeTemplate
@@ -69,12 +74,16 @@ func NewRestRemediate(
 		}
 	}
 
-	method := util.HttpMethodFromString(restCfg.Method, http.MethodPatch)
+	methodStr := cmp.Or(restCfg.Method, http.MethodPatch)
+	methodTemplate, err := util.NewSafeTextTemplate(&methodStr, "method")
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse method template: %w", err)
+	}
 
 	return &Remediator{
 		cli:              cli,
 		actionType:       actionType,
-		method:           method,
+		method:           methodTemplate,
 		endpointTemplate: endpointTmpl,
 		bodyTemplate:     bodyTmpl,
 		setting:          setting,
@@ -89,6 +98,8 @@ type EndpointTemplateParams struct {
 	Profile map[string]any
 	// Params are the rule instance parameters
 	Params map[string]any
+	// EvalResultOutput is the output from the rule evaluation
+	EvalResultOutput any
 }
 
 // Class returns the action type of the remediation engine
@@ -125,15 +136,23 @@ func (r *Remediator) Do(
 		Profile: params.GetRule().Def,
 		Params:  params.GetRule().Params,
 	}
+	if params.GetEvalResult() != nil {
+		retp.EvalResultOutput = params.GetEvalResult().Output
+	}
+
+	method := new(bytes.Buffer)
+	if err := r.method.Execute(ctx, method, retp, methodBytesLimit); err != nil {
+		return nil, fmt.Errorf("cannot execute method template: %w", err)
+	}
 
 	endpoint := new(bytes.Buffer)
-	if err := r.endpointTemplate.Execute(ctx, endpoint, retp, EndpointBytesLimit); err != nil {
+	if err := r.endpointTemplate.Execute(ctx, endpoint, retp, endpointBytesLimit); err != nil {
 		return nil, fmt.Errorf("cannot execute endpoint template: %w", err)
 	}
 
 	body := new(bytes.Buffer)
 	if r.bodyTemplate != nil {
-		if err := r.bodyTemplate.Execute(ctx, body, retp, BodyBytesLimit); err != nil {
+		if err := r.bodyTemplate.Execute(ctx, body, retp, bodyBytesLimit); err != nil {
 			return nil, fmt.Errorf("cannot execute endpoint template: %w", err)
 		}
 	}
@@ -144,16 +163,16 @@ func (r *Remediator) Do(
 	var err error
 	switch r.setting {
 	case models.ActionOptOn:
-		err = r.run(ctx, endpoint.String(), body.Bytes())
+		err = r.run(ctx, method.String(), endpoint.String(), body.Bytes())
 	case models.ActionOptDryRun:
-		err = r.dryRun(ctx, endpoint.String(), body.String())
+		err = r.dryRun(ctx, method.String(), endpoint.String(), body.String())
 	case models.ActionOptOff, models.ActionOptUnknown:
 		err = errors.New("unexpected action")
 	}
 	return nil, err
 }
 
-func (r *Remediator) run(ctx context.Context, endpoint string, body []byte) error {
+func (r *Remediator) run(ctx context.Context, method string, endpoint string, body []byte) error {
 	// create an empty map, not a nil map to avoid passing nil to NewRequest
 	bodyJson := make(map[string]any)
 
@@ -164,7 +183,7 @@ func (r *Remediator) run(ctx context.Context, endpoint string, body []byte) erro
 		}
 	}
 
-	req, err := r.cli.NewRequest(r.method, endpoint, bodyJson)
+	req, err := r.cli.NewRequest(strings.ToUpper(method), endpoint, bodyJson)
 	if err != nil {
 		return fmt.Errorf("cannot create request: %w", err)
 	}
@@ -193,8 +212,8 @@ func (r *Remediator) run(ctx context.Context, endpoint string, body []byte) erro
 	return nil
 }
 
-func (r *Remediator) dryRun(ctx context.Context, endpoint, body string) error {
-	curlCmd, err := util.GenerateCurlCommand(ctx, r.method, r.cli.GetBaseURL(), endpoint, body)
+func (r *Remediator) dryRun(ctx context.Context, method, endpoint, body string) error {
+	curlCmd, err := util.GenerateCurlCommand(ctx, method, r.cli.GetBaseURL(), endpoint, body)
 	if err != nil {
 		return fmt.Errorf("cannot generate curl command: %w", err)
 	}

--- a/internal/util/rest.go
+++ b/internal/util/rest.go
@@ -6,6 +6,7 @@ package util
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -20,12 +21,7 @@ const (
 
 // HttpMethodFromString returns the HTTP method from a string based on upprecase inMeth, defaulting to dfl
 func HttpMethodFromString(inMeth, dfl string) string {
-	method := strings.ToUpper(inMeth)
-	if len(method) == 0 {
-		method = dfl
-	}
-
-	return method
+	return strings.ToUpper(cmp.Or(inMeth, dfl))
 }
 
 // GenerateCurlCommand generates a curl command from a method, apiBaseURL, endpoint, and body


### PR DESCRIPTION
# Summary

Adds the ability to use Go templates in REST methods and YQ expressions.

The former can be used as a more flexible version of the branch protection remediation, to switch between POST and PUT or PATCH depending on whether a rule already exists.

The latter (in combination with rule eval output) will make it easier to fix cases like `dependabot.yml` with the list of missing ecosystems.

Also did a little cleanup of exported -> not-exported methods and types.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Added unit tests, wrote some rules to use the new features.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
