### PR TITLE
Fix WaitGroup race on embeddedpostgres

### DIFF
--- a/internal/db/embedded/testdb.go
+++ b/internal/db/embedded/testdb.go
@@ -104,13 +104,9 @@ func newDBFromShared() (*embeddedpostgres.Config, CancelFunc, error) {
 	}
 	cfg := instance.cfg
 	cfg = cfg.Database(dbName)
-	cancel := func() {
-		instance.lock.Lock()
-		defer instance.lock.Unlock()
-		// TODO: do we care about dropping the database?
-		instance.inFlight.Done()
-	}
-	return &cfg, cancel, nil
+	// Note: because we copy the reference to WaitGroup here, we don't need to
+	// lock the Done call later.
+	return &cfg, instance.inFlight.Done, nil
 }
 
 // GetFakeStore returns a new embedded Postgres database and a cancel function


### PR DESCRIPTION
# Summary

Fixes an [occaisonal test failure](https://github.com/mindersec/minder/actions/runs/16009211483/job/45162919136?pr=5716):

```
 panic: sync: WaitGroup is reused before previous Wait has returned
  
  goroutine 58 [running]:
  sync.(*WaitGroup).Wait(0x325ecc0)
  	/opt/hostedtoolcache/go/1.24.2/x64/src/sync/waitgroup.go:120 +0xe5
  github.com/mindersec/minder/internal/db/embedded.ensurePostgres.func2()
  	/home/runner/work/minder/minder/internal/db/embedded/testdb.go:70 +0x51
  created by github.com/mindersec/minder/internal/db/embedded.ensurePostgres in goroutine 50
  	/home/runner/work/minder/minder/internal/db/embedded/testdb.go:69 +0x9ba
```

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Tested ./internal/providers/... with a count of 50

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
