### PR TITLE
Record image refs during build for later use by cosign

### DIFF
--- a/.mk/helm.mk
+++ b/.mk/helm.mk
@@ -4,7 +4,7 @@
 .PHONY: helm
 helm: ## build the helm chart to a local archive, using ko for the image build
 	cd deployment/helm; \
-	    ko resolve --platform=${KO_PLATFORMS} --base-import-paths --push=${KO_PUSH_IMAGE} -f values.yaml > values.tmp.yaml && \
+	    ko resolve --platform=${KO_PLATFORMS} --base-import-paths --push=${KO_PUSH_IMAGE} --image-refs built-images.yaml -f values.yaml > values.tmp.yaml && \
 		mv values.tmp.yaml values.yaml && \
 		helm dependency update && \
 		helm package --version="${HELM_PACKAGE_VERSION}" . && \


### PR DESCRIPTION
# Summary

Fixes #5727 -- I missed a file change when extracting this for upstream, and "skip if env var is set" kept me from noticing on the final push.

Fixes #5727

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

I set the `PUBLISH_IMAGES` repository variable to `true` and tested with and without this PR:

Without: https://github.com/evankanderson/minder/actions/runs/16031056912
With: https://github.com/evankanderson/minder/actions/runs/16031155307

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
