### PR TITLE
Simplify use of buf.build/go/protovalidate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
           - "go.opentelemetry.io/otel*"
           - "go.opentelemetry.io/contrib*"
           - "github.com/signalfx/splunk-otel-go*"
+      buf:
+        patterns:
+          - "buf.build/*"
   - package-ecosystem: "gomod"
     directory: "tools"
     schedule:

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -43,7 +43,7 @@ func TestProtoValidationInterceptor(t *testing.T) {
 				},
 				Name: "-?invalid",
 			},
-			errMsg:  "Validation failed:\n- Field 'name': value does not match regex pattern",
+			errMsg:  "validation error:\n - name: value does not match regex pattern `^[-[:word:]]*$`",
 			errCode: codes.InvalidArgument,
 		},
 		{
@@ -58,7 +58,7 @@ func TestProtoValidationInterceptor(t *testing.T) {
 					},
 				},
 			},
-			errMsg:  "Validation failed:\n- Field 'entity[0].id': value must be a valid UUID",
+			errMsg:  "validation error:\n - entity[0].id: value must be a valid UUID",
 			errCode: codes.InvalidArgument,
 		},
 	}


### PR DESCRIPTION
# Summary

The generated code still directly imports `buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go`, but it turns out that `formatViolation` was basically duplicating the existing `.Error` method.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Covered by existing tests (updated)

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
