### PR TITLE
Shorten changelogs to avoid winget publishing failures

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -84,6 +84,11 @@ source:
 changelog:
   sort: asc
   use: github
+  filters:
+    exclude:
+      # Don't include dependabot upgrades in the changelog, this can lead to
+      # release notes > 10k, which fails winget validation.
+      - 'build\(deps\): bump'
 # This section defines for which artifact types to generate SBOMs.
 sboms:
   - artifacts: archive


### PR DESCRIPTION
# Summary

https://github.com/microsoft/winget-pkgs/pull/273119 was rejected due to the `ReleaseNotes` being > 10k characters.  Removing dependabot PRs should fix that.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Will need to wait for next release.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
