### PR TITLE
Switch to SetProviderAndWait to avoid data races when switching OpenFeature providers in tests

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -78,13 +78,13 @@ func OpenFeatureProviderFromFlags(ctx context.Context, cfg config.FlagsConfig) {
 	}
 
 	if flagProvider != nil {
-		if err := openfeature.SetProvider(flagProvider); err != nil {
+		if err := openfeature.SetProviderAndWait(flagProvider); err != nil {
 			zerolog.Ctx(ctx).Error().Err(err).Msg("Unable to set flag provider, continuing without flag data")
 		} else {
 			zerolog.Ctx(ctx).Info().Msg("Feature flag provider installed")
 		}
 	} else {
-		if err := openfeature.SetProvider(openfeature.NoopProvider{}); err != nil {
+		if err := openfeature.SetProviderAndWait(openfeature.NoopProvider{}); err != nil {
 			zerolog.Ctx(ctx).Error().Err(err).Msg("Unable to clear flag provider")
 		} else {
 			zerolog.Ctx(ctx).Warn().Msg("No feature flag provider installed")


### PR DESCRIPTION
# Summary

I noticed a number of recent data race failures in `Test_flaggedDriver_Publish`.  It appears that `SetProviderAndWait` avoids some unlocked asynchronous operations that lead to a race in the Go Feature Flag provider's shutdown.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

I ran `go test -cover -race -count 1000 ./internal/events` to reproduce the original issue, and after this change `-count 2000` ran cleanly.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
