### PR TITLE
Specify boilerplate directory, pin boilerplate action

### DIFF
--- a/.github/workflows/boilerplates.yaml
+++ b/.github/workflows/boilerplates.yaml
@@ -43,8 +43,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - uses: chainguard-dev/actions/boilerplate@main
+      - uses: chainguard-dev/actions/boilerplate@6f4f4de7549514e7b659741b30f6476f245600dd # v1.5.3
         with:
           extension: ${{ matrix.extension }}
           language: ${{ matrix.language }}
+          boilerplate-directory: .boilerplate
           exclude: "/mock/|internal/db/|client.gen.go|.pb(.gw)?.go|docs/docs/|internal/auth/keycloak/client/"


### PR DESCRIPTION
# Summary

A bunch of recent PRs seem to have started failing on the boilerplate action trying to find templates in `hack/boilerplate`, where we have them somewhere else.

This is still not ideal, because that action uses a `@latest` from Matt Moore's personal GitHub account, but at least we should be less affected by churn here.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

The CI should provide this.  :grin:

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
