### PR TITLE
fix: request license information from GitLab API

### DIFF
--- a/internal/providers/gitlab/properties_test.go
+++ b/internal/providers/gitlab/properties_test.go
@@ -131,7 +131,6 @@ func Test_gitlabClient_FetchAllProperties(t *testing.T) {
 			},
 		},
 		{
-			name: "repository succeeds",
 			args: args{
 				ctx: context.TODO(),
 				getByProps: properties.NewProperties(map[string]any{
@@ -143,18 +142,29 @@ func Test_gitlabClient_FetchAllProperties(t *testing.T) {
 				properties.RepoPropertyIsPrivate:  true,
 				properties.RepoPropertyIsArchived: false,
 				properties.RepoPropertyIsFork:     false,
+				RepoPropertyLicense:               "mit", // Uses the correct constant
 			}),
 			wantErr: false,
-			gitLabServerMockFunc: func(w http.ResponseWriter, _ *http.Request) {
+			gitLabServerMockFunc: func(w http.ResponseWriter, r *http.Request) {
+				// Verify the query parameter you added is being sent
+				if r.URL.Query().Get("license") != "true" {
+					t.Errorf("expected query param license=true, got %s", r.URL.RawQuery)
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+
 				resp := &gitlab.Project{
-					ID:                1,
-					Name:              "project-1",
-					Description:       "project-1 description",
-					Visibility:        gitlab.PrivateVisibility,
-					Archived:          false,
-					ForkedFromProject: nil,
+					ID:                  1,
+					Name:                "project-1",
+					Description:         "project-1 description",
+					Visibility:          gitlab.PrivateVisibility,
+					Archived:            false,
+					ForkedFromProject:   nil,
 					Namespace: &gitlab.ProjectNamespace{
 						Path: "group",
+					},
+					License: &gitlab.ProjectLicense{
+						Name: "mit", // Changed Key to Name to match repository_properties.go
 					},
 				}
 

--- a/internal/providers/gitlab/properties_test.go
+++ b/internal/providers/gitlab/properties_test.go
@@ -407,3 +407,44 @@ func newTestGitlabProvider(endpoint string) *gitlabClient {
 		cli: &http.Client{},
 	}
 }
+
+
+func TestGitlabProjectToProperties_License(t *testing.T) {
+	t.Parallel()
+
+	// 1. Create a mock GitLab project with a license
+	mockProject := &gitlab.Project{
+		ID:   123,
+		Name: "test-repo",
+		Namespace: &gitlab.ProjectNamespace{
+			Path: "test-org",
+		},
+		License: &gitlab.ProjectLicense{
+			Name: "Apache-2.0",
+		},
+		Visibility:    gitlab.PublicVisibility,
+		Archived:      false,
+		DefaultBranch: "main",
+	}
+
+	// 2. Run the function we want to test
+	props, err := gitlabProjectToProperties(mockProject)
+	if err != nil {
+		t.Fatalf("unexpected error converting project to properties: %v", err)
+	}
+
+	// 3. Verify that the license was successfully populated and is not empty
+	licenseProp := props.GetProperty(RepoPropertyLicense)
+	if licenseProp == nil {
+		t.Fatal("expected license property to be populated, but got nil")
+	}
+
+	licenseVal, err := licenseProp.AsString()
+	if err != nil {
+		t.Fatalf("failed to read license property as string: %v", err)
+	}
+
+	if licenseVal != "Apache-2.0" {
+		t.Errorf("expected license 'Apache-2.0', got '%s'", licenseVal)
+	}
+}

--- a/internal/providers/gitlab/properties_test.go
+++ b/internal/providers/gitlab/properties_test.go
@@ -155,17 +155,17 @@ func Test_gitlabClient_FetchAllProperties(t *testing.T) {
 				}
 
 				resp := &gitlab.Project{
-					ID:                  1,
-					Name:                "project-1",
-					Description:         "project-1 description",
-					Visibility:          gitlab.PrivateVisibility,
-					Archived:            false,
-					ForkedFromProject:   nil,
+					ID:                1,
+					Name:              "project-1",
+					Description:       "project-1 description",
+					Visibility:        gitlab.PrivateVisibility,
+					Archived:          false,
+					ForkedFromProject: nil,
 					Namespace: &gitlab.ProjectNamespace{
 						Path: "group",
 					},
 					License: &gitlab.ProjectLicense{
-						Name: "mit", 
+						Name: "mit",
 					},
 				}
 
@@ -408,4 +408,3 @@ func newTestGitlabProvider(endpoint string) *gitlabClient {
 		cli: &http.Client{},
 	}
 }
-

--- a/internal/providers/gitlab/properties_test.go
+++ b/internal/providers/gitlab/properties_test.go
@@ -143,7 +143,7 @@ func Test_gitlabClient_FetchAllProperties(t *testing.T) {
 				properties.RepoPropertyIsPrivate:  true,
 				properties.RepoPropertyIsArchived: false,
 				properties.RepoPropertyIsFork:     false,
-				RepoPropertyLicense:               "mit", 
+				properties.RepoPropertyLicense:    "mit",
 			}),
 			wantErr: false,
 			gitLabServerMockFunc: func(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/gitlab/properties_test.go
+++ b/internal/providers/gitlab/properties_test.go
@@ -143,7 +143,7 @@ func Test_gitlabClient_FetchAllProperties(t *testing.T) {
 				properties.RepoPropertyIsPrivate:  true,
 				properties.RepoPropertyIsArchived: false,
 				properties.RepoPropertyIsFork:     false,
-				RepoPropertyLicense:               "mit", // Uses the correct constant
+				RepoPropertyLicense:               "mit", 
 			}),
 			wantErr: false,
 			gitLabServerMockFunc: func(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/gitlab/properties_test.go
+++ b/internal/providers/gitlab/properties_test.go
@@ -131,6 +131,7 @@ func Test_gitlabClient_FetchAllProperties(t *testing.T) {
 			},
 		},
 		{
+			name: "repository succeeds",
 			args: args{
 				ctx: context.TODO(),
 				getByProps: properties.NewProperties(map[string]any{
@@ -164,7 +165,7 @@ func Test_gitlabClient_FetchAllProperties(t *testing.T) {
 						Path: "group",
 					},
 					License: &gitlab.ProjectLicense{
-						Name: "mit", // Changed Key to Name to match repository_properties.go
+						Name: "mit", 
 					},
 				}
 
@@ -408,43 +409,3 @@ func newTestGitlabProvider(endpoint string) *gitlabClient {
 	}
 }
 
-
-func TestGitlabProjectToProperties_License(t *testing.T) {
-	t.Parallel()
-
-	// 1. Create a mock GitLab project with a license
-	mockProject := &gitlab.Project{
-		ID:   123,
-		Name: "test-repo",
-		Namespace: &gitlab.ProjectNamespace{
-			Path: "test-org",
-		},
-		License: &gitlab.ProjectLicense{
-			Name: "Apache-2.0",
-		},
-		Visibility:    gitlab.PublicVisibility,
-		Archived:      false,
-		DefaultBranch: "main",
-	}
-
-	// 2. Run the function we want to test
-	props, err := gitlabProjectToProperties(mockProject)
-	if err != nil {
-		t.Fatalf("unexpected error converting project to properties: %v", err)
-	}
-
-	// 3. Verify that the license was successfully populated and is not empty
-	licenseProp := props.GetProperty(RepoPropertyLicense)
-	if licenseProp == nil {
-		t.Fatal("expected license property to be populated, but got nil")
-	}
-
-	licenseVal, err := licenseProp.AsString()
-	if err != nil {
-		t.Fatalf("failed to read license property as string: %v", err)
-	}
-
-	if licenseVal != "Apache-2.0" {
-		t.Errorf("expected license 'Apache-2.0', got '%s'", licenseVal)
-	}
-}

--- a/internal/providers/gitlab/repository_properties.go
+++ b/internal/providers/gitlab/repository_properties.go
@@ -50,6 +50,7 @@ func (c *gitlabClient) getGitLabProject(
 	ctx context.Context, upstreamID string,
 ) (*gitlab.Project, error) {
 	projectURLPath, err := url.JoinPath("projects", url.PathEscape(upstreamID))
+	projectURLPath = projectURLPath + "?license=true"
 	if err != nil {
 		return nil, fmt.Errorf("failed to join URL path for project using upstream ID: %w", err)
 	}

--- a/internal/providers/gitlab/repository_properties.go
+++ b/internal/providers/gitlab/repository_properties.go
@@ -50,10 +50,10 @@ func (c *gitlabClient) getGitLabProject(
 	ctx context.Context, upstreamID string,
 ) (*gitlab.Project, error) {
 	projectURLPath, err := url.JoinPath("projects", url.PathEscape(upstreamID))
-	projectURLPath = projectURLPath + "?license=true"
 	if err != nil {
-		return nil, fmt.Errorf("failed to join URL path for project using upstream ID: %w", err)
+    	return nil, fmt.Errorf("failed to join URL path for project using upstream ID: %w", err)
 	}
+	projectURLPath = projectURLPath + "?license=true"
 
 	// NOTE: We're not using github.com/xanzy/go-gitlab to do the actual
 	// request here because of the way they form authentication for requests.

--- a/internal/providers/gitlab/repository_properties.go
+++ b/internal/providers/gitlab/repository_properties.go
@@ -51,7 +51,7 @@ func (c *gitlabClient) getGitLabProject(
 ) (*gitlab.Project, error) {
 	projectURLPath, err := url.JoinPath("projects", url.PathEscape(upstreamID))
 	if err != nil {
-    	return nil, fmt.Errorf("failed to join URL path for project using upstream ID: %w", err)
+		return nil, fmt.Errorf("failed to join URL path for project using upstream ID: %w", err)
 	}
 	projectURLPath = projectURLPath + "?license=true"
 


### PR DESCRIPTION
# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

# Testing

# Summary

This PR fixes an issue where the `gitlab/license` entity property (`RepoPropertyLicense`) is always empty for GitLab repositories. The fetch logic in `internal/providers/gitlab/repository_properties.go` has been updated to correctly pass the `?license=true` query parameter required by the GitLab API to include license details in the response.

Fixes #6589

# Testing

This is a straightforward API query parameter addition. The underlying `gitlab` provider package logic handles the mapping once the license payload is retrieved via the modified URL path.
