### PR TITLE
Retry remediations after transient errors

### DIFF
--- a/internal/engine/actions/actions.go
+++ b/internal/engine/actions/actions.go
@@ -11,8 +11,12 @@ import (
 	"errors"
 	"fmt"
 	"runtime/debug"
+	"sync"
+	"time"
 
 	"github.com/rs/zerolog"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/mindersec/minder/internal/engine/actions/alert"
@@ -24,6 +28,13 @@ import (
 	"github.com/mindersec/minder/pkg/engine/v1/interfaces"
 	"github.com/mindersec/minder/pkg/profiles/models"
 	provinfv1 "github.com/mindersec/minder/pkg/providers/v1"
+)
+
+const remediationRetryCooloff = 5 * time.Minute
+
+var (
+	remediationCooloffHits metric.Int64Counter
+	actionMetricsInit      sync.Once
 )
 
 // RuleActionsEngine is the engine responsible for processing all actions i.e., remediation and alerts
@@ -38,6 +49,18 @@ func NewRuleActions(
 	provider provinfv1.Provider,
 	actionConfig *models.ActionConfiguration,
 ) (*RuleActionsEngine, error) {
+	actionMetricsInit.Do(func() {
+		var err error
+		remediationCooloffHits, err = otel.Meter("minder").Int64Counter(
+			"actions.remediation_cooloff_hits",
+			metric.WithDescription("Number of remediation retries skipped during the cooloff period"),
+			metric.WithUnit("count"),
+		)
+		if err != nil {
+			zerolog.Ctx(context.Background()).Warn().Err(err).Msg("Creating counter for remediation cooloff hits failed")
+		}
+	})
+
 	// Create the remediation engine
 	remEngine, err := remediate.NewRuleRemediator(ruletype, provider, actionConfig.Remediate)
 	if err != nil {
@@ -94,10 +117,11 @@ func (rae *RuleActionsEngine) DoActions(
 
 	if row := params.GetEvalStatusFromDb(); row != nil {
 		prev = &previousEval{
-			RemediationStatus: RemediationStatus(row.RemStatus),
-			AlertStatus:       AlertStatus(row.AlertStatus),
-			RemediationMeta:   row.RemMetadata,
-			AlertMeta:         row.AlertMetadata,
+			RemediationStatus:      RemediationStatus(row.RemStatus),
+			RemediationLastUpdated: row.RemLastUpdated,
+			AlertStatus:            AlertStatus(row.AlertStatus),
+			RemediationMeta:        row.RemMetadata,
+			AlertMeta:              row.AlertMetadata,
 		}
 	}
 	status := mapEvalStatus(params.GetEvalErr())
@@ -105,7 +129,10 @@ func (rae *RuleActionsEngine) DoActions(
 	// Try remediating
 	if !skipRemediate {
 		// Decide if we should remediate
-		cmd := shouldRemediate(prev, status)
+		cmd, cooloffHit := shouldRemediate(prev, status, time.Now())
+		if cooloffHit && remediationCooloffHits != nil {
+			remediationCooloffHits.Add(ctx, 1)
+		}
 		// Run remediation
 		result.RemediateMeta, result.RemediateErr = rae.processAction(ctx, remediate.ActionType, cmd, ent, params,
 			getRemediationMeta(prev))
@@ -147,7 +174,7 @@ func (rae *RuleActionsEngine) processAction(
 }
 
 // shouldRemediate returns the action command for remediation taking into account previous evaluations
-func shouldRemediate(prevEval *previousEval, evalStatus EvalStatus) engif.ActionCmd {
+func shouldRemediate(prevEval *previousEval, evalStatus EvalStatus, now time.Time) (engif.ActionCmd, bool) {
 	// Get previous Remediation status
 	prevRemediation := RemediationStatusSkipped
 	if prevEval != nil {
@@ -165,25 +192,31 @@ func shouldRemediate(prevEval *previousEval, evalStatus EvalStatus) engif.Action
 		// Case 3 - Evaluation changed from something else to PASSING -> Remediation should be OFF
 		// The Remediation should be OFF (if it wasn't already)
 		if RemediationStatusSkipped != prevRemediation {
-			return engif.ActionCmdOff
+			return engif.ActionCmdOff, false
 		}
 		// We should do nothing if remediation was already skipped
-		return engif.ActionCmdDoNothing
+		return engif.ActionCmdDoNothing, false
 	case EvalStatusFailure:
 		// Case 4 - Evaluation has changed from something else to FAILED -> Remediation should be ON
-		// Retry failed remediations so they can recover after their underlying error is fixed.
-		if RemediationStatusSkipped == prevRemediation || RemediationStatusError == prevRemediation {
-			return engif.ActionCmdOn
+		if RemediationStatusSkipped == prevRemediation {
+			return engif.ActionCmdOn, false
+		}
+		// Retry failed remediations after a cooloff so immediate re-evaluations cannot busy-loop.
+		if RemediationStatusError == prevRemediation {
+			if now.Before(prevEval.RemediationLastUpdated.Add(remediationRetryCooloff)) {
+				return engif.ActionCmdDoNothing, true
+			}
+			return engif.ActionCmdOn, false
 		}
 		// Do nothing while remediation is pending or after it has completed.
-		return engif.ActionCmdDoNothing
+		return engif.ActionCmdDoNothing, false
 	case EvalStatusSkipped:
 	case EvalStatusPending:
-		return engif.ActionCmdDoNothing
+		return engif.ActionCmdDoNothing, false
 	}
 
 	// Default to do nothing
-	return engif.ActionCmdDoNothing
+	return engif.ActionCmdDoNothing, false
 }
 
 // shouldAlert returns the action command for alerting taking into account previous evaluations

--- a/internal/engine/actions/actions.go
+++ b/internal/engine/actions/actions.go
@@ -171,11 +171,11 @@ func shouldRemediate(prevEval *previousEval, evalStatus EvalStatus) engif.Action
 		return engif.ActionCmdDoNothing
 	case EvalStatusFailure:
 		// Case 4 - Evaluation has changed from something else to FAILED -> Remediation should be ON
-		// We should remediate only if the previous remediation was skipped, so we don't risk endless remediation loops
-		if RemediationStatusSkipped == prevRemediation {
+		// Retry failed remediations so they can recover after their underlying error is fixed.
+		if RemediationStatusSkipped == prevRemediation || RemediationStatusError == prevRemediation {
 			return engif.ActionCmdOn
 		}
-		// Do nothing if the Remediation is something else other than skipped, i.e. pending, success, error, etc.
+		// Do nothing while remediation is pending or after it has completed.
 		return engif.ActionCmdDoNothing
 	case EvalStatusSkipped:
 	case EvalStatusPending:

--- a/internal/engine/actions/actions_test.go
+++ b/internal/engine/actions/actions_test.go
@@ -6,6 +6,7 @@ package actions
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -16,13 +17,16 @@ import (
 
 func TestShouldRemediate(t *testing.T) {
 	t.Parallel()
+	now := time.Date(2026, time.August, 11, 0, 0, 0, 0, time.UTC)
 
 	tests := []struct {
-		name       string
-		prevStatus RemediationStatus
-		hasPrev    bool
-		evalErr    error
-		expected   engif.ActionCmd
+		name            string
+		prevStatus      RemediationStatus
+		lastUpdated     time.Time
+		hasPrev         bool
+		evalErr         error
+		expected        engif.ActionCmd
+		expectedCooloff bool
 	}{
 		// Happy path: eval success
 		{
@@ -71,11 +75,21 @@ func TestShouldRemediate(t *testing.T) {
 			expected:   engif.ActionCmdOff,
 		},
 		{
-			name:       "eval failure, prev error -> on",
-			prevStatus: RemediationStatusError,
-			hasPrev:    true,
-			evalErr:    enginerr.NewErrEvaluationFailed("failed"),
-			expected:   engif.ActionCmdOn,
+			name:            "eval failure, recent prev error -> do nothing",
+			prevStatus:      RemediationStatusError,
+			lastUpdated:     now.Add(-remediationRetryCooloff + time.Second),
+			hasPrev:         true,
+			evalErr:         enginerr.NewErrEvaluationFailed("failed"),
+			expected:        engif.ActionCmdDoNothing,
+			expectedCooloff: true,
+		},
+		{
+			name:        "eval failure, prev error at cooloff boundary -> on",
+			prevStatus:  RemediationStatusError,
+			lastUpdated: now.Add(-remediationRetryCooloff),
+			hasPrev:     true,
+			evalErr:     enginerr.NewErrEvaluationFailed("failed"),
+			expected:    engif.ActionCmdOn,
 		},
 		{
 			name:       "eval error, prev error -> off",
@@ -118,11 +132,15 @@ func TestShouldRemediate(t *testing.T) {
 			t.Parallel()
 			var prev *previousEval
 			if tt.hasPrev {
-				prev = &previousEval{RemediationStatus: tt.prevStatus}
+				prev = &previousEval{
+					RemediationStatus:      tt.prevStatus,
+					RemediationLastUpdated: tt.lastUpdated,
+				}
 			}
 			status := mapEvalStatus(tt.evalErr)
-			got := shouldRemediate(prev, status)
+			got, cooloffHit := shouldRemediate(prev, status, now)
 			assert.Equal(t, tt.expected, got)
+			assert.Equal(t, tt.expectedCooloff, cooloffHit)
 		})
 	}
 }

--- a/internal/engine/actions/actions_test.go
+++ b/internal/engine/actions/actions_test.go
@@ -71,11 +71,11 @@ func TestShouldRemediate(t *testing.T) {
 			expected:   engif.ActionCmdOff,
 		},
 		{
-			name:       "eval failure, prev error -> do nothing",
+			name:       "eval failure, prev error -> on",
 			prevStatus: RemediationStatusError,
 			hasPrev:    true,
 			evalErr:    enginerr.NewErrEvaluationFailed("failed"),
-			expected:   engif.ActionCmdDoNothing,
+			expected:   engif.ActionCmdOn,
 		},
 		{
 			name:       "eval error, prev error -> off",

--- a/internal/engine/actions/types.go
+++ b/internal/engine/actions/types.go
@@ -3,7 +3,10 @@
 
 package actions
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // RemediationStatus represents remediation state.
 type RemediationStatus string
@@ -44,8 +47,9 @@ const (
 
 // previousEval captures previous remediation and alert state.
 type previousEval struct {
-	RemediationStatus RemediationStatus
-	AlertStatus       AlertStatus
-	RemediationMeta   json.RawMessage
-	AlertMeta         json.RawMessage
+	RemediationStatus      RemediationStatus
+	RemediationLastUpdated time.Time
+	AlertStatus            AlertStatus
+	RemediationMeta        json.RawMessage
+	AlertMeta              json.RawMessage
 }


### PR DESCRIPTION
## Summary

- retry remediations whose previous attempt ended in an error after a fixed five-minute cooloff
- suppress immediate retry loops while leaving skipped, pending, and completed remediation behavior unchanged
- count suppressed retries with the `actions.remediation_cooloff_hits` OpenTelemetry counter
- cover both sides of the cooloff boundary with deterministic decision-table tests

## Root cause

`shouldRemediate` only returned `ActionCmdOn` when the previous remediation status was `skipped`. A transient or corrected remediation error therefore left the rule stuck in `error`. Retrying immediately, however, could busy-loop when remediation-triggered changes caused another evaluation.

The decision now uses the persisted `RemLastUpdated` timestamp: a failed evaluation inside the five-minute cooloff remains a no-op, while the boundary and later evaluations retry.

## Validation

- `go test ./internal/engine/actions`
- `go vet ./internal/engine/actions`
- `gofmt -d internal/engine/actions/actions.go internal/engine/actions/actions_test.go internal/engine/actions/types.go` (no output)

Closes #4949