### PR TITLE
fix(ruletest): initialize params map to prevent panic on template rendering

### DIFF
--- a/pkg/ruletest/eval.go
+++ b/pkg/ruletest/eval.go
@@ -58,7 +58,7 @@ func (tr *testCaseRunner) builtinEval(
 		return nil, fmt.Errorf("invalid profile argument: %w", err)
 	}
 
-	var paramsMap map[string]any
+	paramsMap := make(map[string]any)
 	if paramsDict != nil {
 		paramsMap, err = dictToGoMap(paramsDict)
 		if err != nil {

--- a/pkg/ruletest/testdata/param_defaults_rule.yaml
+++ b/pkg/ruletest/testdata/param_defaults_rule.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
+# SPDX-License-Identifier: Apache-2.0
+
+version: v1
+type: rule-type
+name: param_defaults_rule
+context:
+  project: 00000000-0000-0000-0000-000000000000
+description: 'Test rule that uses param_schema with defaults in endpoint template.'
+display_name: 'Param Defaults Test Rule'
+release_phase: alpha
+severity:
+  value: low
+guidance: 'Test rule for verifying param defaults are applied.'
+def:
+  in_entity: repository
+  param_schema:
+    properties:
+      branch:
+        type: string
+        description: "Branch name to check."
+        default: ""
+  rule_schema:
+    type: object
+    properties: {}
+  ingest:
+    type: rest
+    rest:
+      endpoint: '{{ $branch := index .Params "branch" }}/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{if ne $branch "" }}{{ $branch }}{{ else }}{{ .Entity.DefaultBranch }}{{ end }}/protection'
+      parse: 'json'
+  eval:
+    type: jq
+    jq:
+      - ingested:
+          def: ".allow_deletions.enabled"
+        constant: false

--- a/pkg/ruletest/testdata/param_defaults_test.star
+++ b/pkg/ruletest/testdata/param_defaults_test.star
@@ -1,0 +1,26 @@
+# Tests that rules with param_schema defaults work without explicit params.
+# Before the fix, omitting params= would cause a panic because the
+# template `index .Params "branch"` would receive a nil map.
+
+def test_param_defaults_applied():
+    """Eval should pass when params is omitted and param_schema has defaults."""
+    res = eval(
+        rule="param_defaults_rule",
+        entity={"owner": "test", "name": "repo", "type": "repository", "default_branch": "main"},
+        mock_http={
+            "/repos/test/repo/branches/main/protection": body('{"allow_deletions": {"enabled": false}}')
+        }
+    )
+    assert.eq(res["status"], "pass")
+
+def test_param_defaults_with_explicit_params():
+    """Eval should use explicit params when provided."""
+    res = eval(
+        rule="param_defaults_rule",
+        entity={"owner": "test", "name": "repo", "type": "repository", "default_branch": "main"},
+        params={"branch": "develop"},
+        mock_http={
+            "/repos/test/repo/branches/develop/protection": body('{"allow_deletions": {"enabled": false}}')
+        }
+    )
+    assert.eq(res["status"], "pass")


### PR DESCRIPTION
## Summary

When a Starlark test omits the `params=` argument, `paramsMap` was `nil`. This caused the rule type engine to skip `ValidateParamsAgainstSchema`, so `param_schema` defaults (e.g. `branch: ""`) were never applied. When the ingestion template later called `index .Params "branch"`, it panicked on the nil map, resulting in an `"internal minder error"`.

**Fix:** Initialize `paramsMap` as an empty map (`make(map[string]any)`) so the engine always runs schema validation and applies defaults.

This unblocks 4 failing tests in [minder-rules-and-profiles#418](https://github.com/mindersec/minder-rules-and-profiles/pull/418):
- `branch_protection_allow_deletions_test.star/test_force_push_not_allowed`
- `branch_protection_allow_force_pushes_test.star/test_force_push_not_allowed`
- `branch_protection_require_status_checks_test.star/test_status_checks_required`
- `branch_protection_require_status_checks_test.star/test_status_checks_required_with_strict_mode`

## Testing

- **Unit tests:** `go test ./pkg/ruletest/...` -- all 21 tests pass (including 2 new tests)
- **Integration:** Built `mindev` from this branch and ran `mindev test .` against the `minder-rules-and-profiles` repo -- all 57 tests pass (4 were previously failing)

New test files added:
- `pkg/ruletest/testdata/param_defaults_rule.yaml` -- rule type with `param_schema` defaults and a templated endpoint that references `.Params`
- `pkg/ruletest/testdata/param_defaults_test.star` -- tests that eval works both with and without explicit `params=`
