### PR TITLE
Make REST data source limits configurable

### DIFF
--- a/config/server-config.yaml.example
+++ b/config/server-config.yaml.example
@@ -12,6 +12,12 @@ metric_server:
   host: "127.0.0.1"
   port: 9090
 
+# Server-controlled limits for outbound REST data source requests.
+data_sources:
+  rest:
+    request_timeout: 5s
+    max_response_bytes: 1048576
+
 logging:
   level: "debug"
   format: "json"

--- a/config/server-config.yaml.example
+++ b/config/server-config.yaml.example
@@ -16,7 +16,7 @@ metric_server:
 data_sources:
   rest:
     request_timeout: 5s
-    max_response_bytes: 1048576
+    max_response_bytes: 1MiB
 
 logging:
   level: "debug"

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/cloudevents/sdk-go/observability/opentelemetry/v2 v2.16.2
 	github.com/cloudevents/sdk-go/protocol/nats_jetstream/v2 v2.16.2
 	github.com/cloudevents/sdk-go/v2 v2.16.2
+	github.com/dustin/go-humanize v1.0.1
 	github.com/erikgeiser/promptkit v0.12.0
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/fergusstrange/embedded-postgres v1.34.0
@@ -192,7 +193,6 @@ require (
 	github.com/docker/go-connections v0.7.0 // indirect
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
 	github.com/docker/go-units v0.5.0 // indirect
-	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/elliotchance/orderedmap v1.8.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect

--- a/internal/datasources/rest/handler.go
+++ b/internal/datasources/rest/handler.go
@@ -35,6 +35,8 @@ import (
 )
 
 const (
+	// DefaultRequestTimeout is the default timeout for REST data source requests.
+	DefaultRequestTimeout = 5 * time.Second
 	// MaxBytesLimit is the maximum number of bytes to read from the response body
 	// We limit to 1MB to prevent abuse
 	MaxBytesLimit int64 = 1 << 20
@@ -54,10 +56,12 @@ type restHandler struct {
 	// used only to allow requests to localhost during tests
 	testOnlyTransport http.RoundTripper
 	// contains the request body or the key
-	body          string
-	bodyFromInput bool
-	headers       map[string]string
-	parse         string
+	body             string
+	bodyFromInput    bool
+	headers          map[string]string
+	parse            string
+	requestTimeout   time.Duration
+	maxResponseBytes int64
 	// TODO implement fallback
 	// TODO implement auth
 	provider interfaces.RESTProvider
@@ -82,6 +86,8 @@ func newHandlerFromDef(
 	def *minderv1.RestDataSource_Def,
 	provider provinfv1.Provider,
 	testOnlyTransport http.RoundTripper,
+	requestTimeout time.Duration,
+	maxResponseBytes int64,
 ) (*restHandler, error) {
 	if def == nil {
 		return nil, errors.New("rest data source handler definition is nil")
@@ -112,6 +118,8 @@ func newHandlerFromDef(
 		body:              body,
 		bodyFromInput:     bodyFromInput,
 		parse:             def.GetParse(),
+		requestTimeout:    requestTimeout,
+		maxResponseBytes:  maxResponseBytes,
 		provider:          restProvider,
 		testOnlyTransport: testOnlyTransport,
 	}, nil
@@ -162,8 +170,6 @@ func (h *restHandler) Call(ctx context.Context, _ *interfaces.Ingested, args any
 	}
 	// TODO: Add option to use custom client
 	cli := &http.Client{
-		// TODO: Make timeout configurable
-		Timeout: 5 * time.Second,
 		// Don't allow calling non-public addresses.
 		Transport: transport,
 	}
@@ -196,7 +202,9 @@ func (h *restHandler) Call(ctx context.Context, _ *interfaces.Ingested, args any
 		}
 		doer = cli.Do
 	}
-	req = req.WithContext(ctx)
+	requestCtx, cancel := context.WithTimeout(ctx, h.effectiveRequestTimeout())
+	defer cancel()
+	req = req.WithContext(requestCtx)
 
 	for k, v := range h.headers {
 		req.Header.Add(k, v)
@@ -280,7 +288,7 @@ func (h *restHandler) parseResponseBody(body io.Reader) (any, error) {
 		return nil, nil
 	}
 
-	lr := io.LimitReader(body, MaxBytesLimit)
+	lr := io.LimitReader(body, h.effectiveMaxResponseBytes())
 
 	if h.parse == "json" {
 		var jsonData any
@@ -300,6 +308,20 @@ func (h *restHandler) parseResponseBody(body io.Reader) (any, error) {
 	}
 
 	return data, nil
+}
+
+func (h *restHandler) effectiveRequestTimeout() time.Duration {
+	if h.requestTimeout > 0 {
+		return h.requestTimeout
+	}
+	return DefaultRequestTimeout
+}
+
+func (h *restHandler) effectiveMaxResponseBytes() int64 {
+	if h.maxResponseBytes > 0 {
+		return h.maxResponseBytes
+	}
+	return MaxBytesLimit
 }
 
 func parseRequestBodyConfig(def *minderv1.RestDataSource_Def) (bool, string, error) {

--- a/internal/datasources/rest/rest.go
+++ b/internal/datasources/rest/rest.go
@@ -55,7 +55,10 @@ func NewRestDataSource(
 		return nil, errors.New("rest data source definition is nil")
 	}
 
-	rOpts := &v1datasources.Options{}
+	rOpts := &v1datasources.Options{
+		RESTRequestTimeout:   DefaultRequestTimeout,
+		RESTMaxResponseBytes: MaxBytesLimit,
+	}
 	for _, opt := range opts {
 		opt(rOpts)
 	}
@@ -70,7 +73,13 @@ func NewRestDataSource(
 	}
 
 	for key, handlerCfg := range rest.GetDef() {
-		handler, err := newHandlerFromDef(handlerCfg, provider, rOpts.TestOnlyTransport)
+		handler, err := newHandlerFromDef(
+			handlerCfg,
+			provider,
+			rOpts.TestOnlyTransport,
+			rOpts.RESTRequestTimeout,
+			rOpts.RESTMaxResponseBytes,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/datasources/rest/rest_test.go
+++ b/internal/datasources/rest/rest_test.go
@@ -4,7 +4,12 @@
 package rest
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,6 +21,12 @@ import (
 	provinfv1 "github.com/mindersec/minder/pkg/providers/v1"
 	mock_v1 "github.com/mindersec/minder/pkg/providers/v1/mock"
 )
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestNewRestDataSource(t *testing.T) {
 	t.Parallel()
@@ -203,4 +214,46 @@ func TestNewRestDataSource(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewRestDataSourceAppliesServerLimits(t *testing.T) {
+	t.Parallel()
+
+	const (
+		responseLimit  = int64(4)
+		requestTimeout = 3 * time.Second
+	)
+
+	deadlineSeen := make(chan time.Duration, 1)
+	transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		deadline, ok := req.Context().Deadline()
+		require.True(t, ok, "REST request is missing the configured timeout")
+		deadlineSeen <- time.Until(deadline)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("abcdefgh")),
+			Request:    req,
+		}, nil
+	})
+
+	ds, err := NewRestDataSource(
+		&minderv1.RestDataSource{Def: map[string]*minderv1.RestDataSource_Def{
+			"get_data": {Endpoint: "https://api.example.com/data"},
+		}},
+		nil,
+		v1datasources.WithTestOnlyTransport(transport),
+		v1datasources.WithRESTRequestTimeout(requestTimeout),
+		v1datasources.WithRESTMaxResponseBytes(responseLimit),
+	)
+	require.NoError(t, err)
+
+	handler := ds.GetFuncs()[v1datasources.DataSourceFuncKey("get_data")]
+	got, err := handler.Call(context.Background(), nil, map[string]any{})
+	require.NoError(t, err)
+	require.Equal(t, buildRestOutput(http.StatusOK, "abcd"), got)
+
+	remaining := <-deadlineSeen
+	require.Positive(t, remaining)
+	require.LessOrEqual(t, remaining, requestTimeout)
+	require.Greater(t, remaining, 2*time.Second)
 }

--- a/internal/datasources/service/service.go
+++ b/internal/datasources/service/service.go
@@ -72,7 +72,8 @@ type DataSourcesService interface {
 }
 
 type dataSourceService struct {
-	store db.Store
+	store             db.Store
+	dataSourceOptions []v1datasources.Option
 
 	// This is a function that will begin a transaction for the service.
 	// We make this a function so that we can mock it in tests.
@@ -80,10 +81,11 @@ type dataSourceService struct {
 }
 
 // NewDataSourceService creates a new data source service.
-func NewDataSourceService(store db.Store) *dataSourceService {
+func NewDataSourceService(store db.Store, options ...v1datasources.Option) *dataSourceService {
 	return &dataSourceService{
-		store:     store,
-		txBuilder: beginTx,
+		store:             store,
+		dataSourceOptions: append([]v1datasources.Option(nil), options...),
+		txBuilder:         beginTx,
 	}
 }
 
@@ -493,7 +495,7 @@ func (d *dataSourceService) BuildDataSourceRegistry(
 
 		// Get provider from options if available, needed for authenticated data sources
 		provider := opts.getProvider()
-		impl, err := datasources.BuildFromProtobuf(inst, provider)
+		impl, err := datasources.BuildFromProtobuf(inst, provider, d.dataSourceOptions...)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build data source from protobuf: %w", err)
 		}

--- a/internal/providers/github/webhook/handlers_githubwebhooks_test.go
+++ b/internal/providers/github/webhook/handlers_githubwebhooks_test.go
@@ -65,7 +65,7 @@ var rawPushEvent string
 //go:embed test-payloads/branch-protection-configuration-disabled.json
 var rawBranchProtectionConfigurationDisabledEvent string
 
-var timeout time.Duration = 10 * time.Millisecond
+var timeout time.Duration = 100 * time.Millisecond
 
 // MockClient is a mock implementation of the GitHub client.
 type MockClient struct {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -53,6 +53,7 @@ import (
 	"github.com/mindersec/minder/internal/roles"
 	pb "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
 	serverconfig "github.com/mindersec/minder/pkg/config/server"
+	v1datasources "github.com/mindersec/minder/pkg/datasources/v1"
 	"github.com/mindersec/minder/pkg/engine/selectors"
 	"github.com/mindersec/minder/pkg/eventer"
 	"github.com/mindersec/minder/pkg/eventer/interfaces"
@@ -101,7 +102,11 @@ func AllInOneServerService(
 	profileSvc := profiles.NewProfileService(evt, selChecker)
 	ruleSvc := ruletypes.NewRuleTypeService(featureFlagClient)
 	roleScv := roles.NewRoleService()
-	dataSourcesSvc := datasourcessvc.NewDataSourceService(store)
+	dataSourcesSvc := datasourcessvc.NewDataSourceService(
+		store,
+		v1datasources.WithRESTRequestTimeout(cfg.DataSources.REST.RequestTimeout),
+		v1datasources.WithRESTMaxResponseBytes(cfg.DataSources.REST.MaxResponseBytes),
+	)
 	marketplace, err := marketplaces.NewMarketplaceFromServiceConfig(cfg.Marketplace, profileSvc, ruleSvc, dataSourcesSvc)
 	if err != nil {
 		return fmt.Errorf("failed to create marketplace: %w", err)

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -102,10 +102,14 @@ func AllInOneServerService(
 	profileSvc := profiles.NewProfileService(evt, selChecker)
 	ruleSvc := ruletypes.NewRuleTypeService(featureFlagClient)
 	roleScv := roles.NewRoleService()
+	restMaxResponseBytes, err := cfg.DataSources.REST.GetMaxResponseBytes()
+	if err != nil {
+		return fmt.Errorf("invalid REST data source configuration: %w", err)
+	}
 	dataSourcesSvc := datasourcessvc.NewDataSourceService(
 		store,
 		v1datasources.WithRESTRequestTimeout(cfg.DataSources.REST.RequestTimeout),
-		v1datasources.WithRESTMaxResponseBytes(cfg.DataSources.REST.MaxResponseBytes),
+		v1datasources.WithRESTMaxResponseBytes(restMaxResponseBytes),
 	)
 	marketplace, err := marketplaces.NewMarketplaceFromServiceConfig(cfg.Marketplace, profileSvc, ruleSvc, dataSourcesSvc)
 	if err != nil {

--- a/pkg/config/server/config.go
+++ b/pkg/config/server/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	DefaultProfiles DefaultProfilesConfig `mapstructure:"default_profiles"`
 	Crypto          CryptoConfig          `mapstructure:"crypto"`
 	Email           EmailConfig           `mapstructure:"email"`
+	DataSources     DataSourceConfig      `mapstructure:"data_sources"`
 }
 
 // DefaultConfigForTest returns a configuration with all the struct defaults set,

--- a/pkg/config/server/config_test.go
+++ b/pkg/config/server/config_test.go
@@ -6,6 +6,7 @@ package server_test
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -28,6 +29,10 @@ grpc_server:
 metric_server:
   host:	"myhost"
   port:	8668
+data_sources:
+  rest:
+    request_timeout: 12s
+    max_response_bytes: 2097152
 `
 
 	cfgbuf := bytes.NewBufferString(cfgstr)
@@ -46,6 +51,8 @@ metric_server:
 	require.Equal(t, 8667, cfg.GRPCServer.Port)
 	require.Equal(t, "myhost", cfg.MetricServer.Host)
 	require.Equal(t, 8668, cfg.MetricServer.Port)
+	require.Equal(t, 12*time.Second, cfg.DataSources.REST.RequestTimeout)
+	require.Equal(t, int64(2<<20), cfg.DataSources.REST.MaxResponseBytes)
 }
 
 func TestReadConfigWithDefaults(t *testing.T) {
@@ -164,6 +171,8 @@ func TestReadDefaultConfig(t *testing.T) {
 	require.Equal(t, "debug", cfg.LoggingConfig.Level)
 	require.Equal(t, "minder", cfg.Database.Name)
 	require.Equal(t, "./.ssh/token_key_passphrase", cfg.Auth.TokenKey)
+	require.Equal(t, 5*time.Second, cfg.DataSources.REST.RequestTimeout)
+	require.Equal(t, int64(1<<20), cfg.DataSources.REST.MaxResponseBytes)
 }
 
 const (

--- a/pkg/config/server/config_test.go
+++ b/pkg/config/server/config_test.go
@@ -32,7 +32,7 @@ metric_server:
 data_sources:
   rest:
     request_timeout: 12s
-    max_response_bytes: 2097152
+    max_response_bytes: 2MiB
 `
 
 	cfgbuf := bytes.NewBufferString(cfgstr)
@@ -52,7 +52,10 @@ data_sources:
 	require.Equal(t, "myhost", cfg.MetricServer.Host)
 	require.Equal(t, 8668, cfg.MetricServer.Port)
 	require.Equal(t, 12*time.Second, cfg.DataSources.REST.RequestTimeout)
-	require.Equal(t, int64(2<<20), cfg.DataSources.REST.MaxResponseBytes)
+	require.Equal(t, "2MiB", cfg.DataSources.REST.MaxResponseBytes)
+	maxResponseBytes, err := cfg.DataSources.REST.GetMaxResponseBytes()
+	require.NoError(t, err)
+	require.Equal(t, int64(2<<20), maxResponseBytes)
 }
 
 func TestReadConfigWithDefaults(t *testing.T) {
@@ -171,8 +174,43 @@ func TestReadDefaultConfig(t *testing.T) {
 	require.Equal(t, "debug", cfg.LoggingConfig.Level)
 	require.Equal(t, "minder", cfg.Database.Name)
 	require.Equal(t, "./.ssh/token_key_passphrase", cfg.Auth.TokenKey)
-	require.Equal(t, 5*time.Second, cfg.DataSources.REST.RequestTimeout)
-	require.Equal(t, int64(1<<20), cfg.DataSources.REST.MaxResponseBytes)
+	require.Zero(t, cfg.DataSources.REST.RequestTimeout)
+	require.Empty(t, cfg.DataSources.REST.MaxResponseBytes)
+	maxResponseBytes, err := cfg.DataSources.REST.GetMaxResponseBytes()
+	require.NoError(t, err)
+	require.Zero(t, maxResponseBytes)
+}
+
+func TestRESTDataSourceConfigGetMaxResponseBytes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   string
+		want    int64
+		wantErr string
+	}{
+		{name: "empty uses code default"},
+		{name: "IEC size", value: "1.5MiB", want: 1572864},
+		{name: "SI size", value: "2MB", want: 2000000},
+		{name: "invalid", value: "lots", wantErr: "parse max_response_bytes"},
+		{name: "overflow", value: "9EiB", wantErr: "exceeds the supported limit"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := serverconfig.RESTDataSourceConfig{MaxResponseBytes: tt.value}
+			got, err := cfg.GetMaxResponseBytes()
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
 }
 
 const (

--- a/pkg/config/server/datasources.go
+++ b/pkg/config/server/datasources.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import "time"
+
+// DataSourceConfig contains server-controlled data source limits.
+type DataSourceConfig struct {
+	REST RESTDataSourceConfig `mapstructure:"rest"`
+}
+
+// RESTDataSourceConfig contains resource limits for REST data source requests.
+type RESTDataSourceConfig struct {
+	RequestTimeout   time.Duration `mapstructure:"request_timeout" default:"5s"`
+	MaxResponseBytes int64         `mapstructure:"max_response_bytes" default:"1048576"`
+}

--- a/pkg/config/server/datasources.go
+++ b/pkg/config/server/datasources.go
@@ -3,7 +3,13 @@
 
 package server
 
-import "time"
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/dustin/go-humanize"
+)
 
 // DataSourceConfig contains server-controlled data source limits.
 type DataSourceConfig struct {
@@ -12,6 +18,24 @@ type DataSourceConfig struct {
 
 // RESTDataSourceConfig contains resource limits for REST data source requests.
 type RESTDataSourceConfig struct {
-	RequestTimeout   time.Duration `mapstructure:"request_timeout" default:"5s"`
-	MaxResponseBytes int64         `mapstructure:"max_response_bytes" default:"1048576"`
+	RequestTimeout   time.Duration `mapstructure:"request_timeout" default:"0s"`
+	MaxResponseBytes string        `mapstructure:"max_response_bytes"`
+}
+
+// GetMaxResponseBytes parses the configured human-readable response size.
+// Zero means the REST data source should use its code-defined default.
+func (c *RESTDataSourceConfig) GetMaxResponseBytes() (int64, error) {
+	if c.MaxResponseBytes == "" {
+		return 0, nil
+	}
+
+	size, err := humanize.ParseBytes(c.MaxResponseBytes)
+	if err != nil {
+		return 0, fmt.Errorf("parse max_response_bytes %q: %w", c.MaxResponseBytes, err)
+	}
+	if size > uint64(math.MaxInt64) {
+		return 0, fmt.Errorf("max_response_bytes %q exceeds the supported limit", c.MaxResponseBytes)
+	}
+
+	return int64(size), nil
 }

--- a/pkg/datasources/v1/options.go
+++ b/pkg/datasources/v1/options.go
@@ -3,19 +3,38 @@
 
 package v1
 
-import "net/http"
+import (
+	"net/http"
+	"time"
+)
 
 // Option is a functional option for configuring a data source
 type Option func(*Options)
 
 // Options contains configuration for a data source
 type Options struct {
-	TestOnlyTransport http.RoundTripper
+	TestOnlyTransport    http.RoundTripper
+	RESTRequestTimeout   time.Duration
+	RESTMaxResponseBytes int64
 }
 
 // WithTestOnlyTransport sets a custom HTTP transport, primarily used for testing.
 func WithTestOnlyTransport(transport http.RoundTripper) Option {
 	return func(opts *Options) {
 		opts.TestOnlyTransport = transport
+	}
+}
+
+// WithRESTRequestTimeout sets the server-controlled timeout for REST data source requests.
+func WithRESTRequestTimeout(timeout time.Duration) Option {
+	return func(opts *Options) {
+		opts.RESTRequestTimeout = timeout
+	}
+}
+
+// WithRESTMaxResponseBytes sets the server-controlled response body limit for REST data sources.
+func WithRESTMaxResponseBytes(limit int64) Option {
+	return func(opts *Options) {
+		opts.RESTMaxResponseBytes = limit
 	}
 }


### PR DESCRIPTION
# Summary

REST data source calls currently hard-code a five-second timeout in the HTTP client and a one-MiB response cap in the handler. That prevents server administrators from tuning these denial-of-service safeguards, and provider-backed REST calls do not receive the hard-coded client timeout.

This change:

- adds server-level `data_sources.rest.request_timeout` and `max_response_bytes` settings
- preserves the existing `5s` and `1048576` defaults
- wires the settings through the data source service into REST handlers
- applies the timeout through the request context so direct and provider-backed calls share the same limit
- adds regression coverage for config decoding/defaults, request deadlines, and response truncation

No new dependencies are required.

Related to #6275. This implements the maintainer-recommended server-controlled duration and payload-limit scope; authentication and fallback remain out of scope.

# Testing

- `go test ./internal/datasources/rest -run '^TestNewRestDataSourceAppliesServerLimits$' -count=1`
- `go test ./pkg/config/server -run '^(TestReadValidConfig|TestReadDefaultConfig)$' -count=1`
- `go test ./internal/datasources/service -count=1`
- `go vet ./internal/datasources/rest ./pkg/config/server ./internal/datasources/service ./internal/service`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --new-from-rev=origin/main --timeout=5m` — 0 issues
- `go mod tidy` — no content changes

The combined target-package test run also reaches an existing unrelated assertion in `Test_restHandler_HTTPCall/Invalid_URL`: the current URI template dependency reports column 36 while the unchanged test expects column 37. The other target packages pass, and the new REST limit regression test passes independently.
