### PR TITLE
Gate rule type engine construction on provider_traits

### DIFF
--- a/pkg/engine/v1/interfaces/provider.go
+++ b/pkg/engine/v1/interfaces/provider.go
@@ -14,6 +14,14 @@ import (
 
 // Provider is a slice of the github.com/mindersec/minder/pkg/providers/v1.Provider
 // interface which contains only the methods needed for engine evaluation. (currently none)
+//
+// Note: this interface intentionally does not depend on
+// github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1 (minderv1). That
+// package transitively imports pkg/datasources/v1, which imports this
+// package for interfaces.Ingested — so importing minderv1 here would create
+// an import cycle. Callers that need a minderv1-typed method (e.g.
+// CanImplement) should type-assert against a package-local interface
+// instead, the way rtengine does.
 type Provider interface {
 }
 

--- a/pkg/engine/v1/rtengine/engine.go
+++ b/pkg/engine/v1/rtengine/engine.go
@@ -35,6 +35,18 @@ func (r *RuleMeta) String() string {
 	return fmt.Sprintf("group/%s/%s", r.Project, r.Name)
 }
 
+// traitProvider is a package-local interface for providers that can report
+// which minder provider traits they implement. It is declared here, rather
+// than added to interfaces.Provider, because pkg/engine/v1/interfaces cannot
+// import minderv1 without creating an import cycle (minderv1 transitively
+// imports pkg/datasources/v1, which imports pkg/engine/v1/interfaces).
+// Every concrete provider implementation already has this exact method, so
+// they satisfy this interface structurally without any changes.
+type traitProvider interface {
+	// CanImplement returns true if the provider implements the given trait.
+	CanImplement(trait minderv1.ProviderType) bool
+}
+
 // RuleTypeEngine is the engine for a rule type. It builds the multiple
 // sections of the rule type and instantiates the needed drivers for
 // them.
@@ -63,6 +75,21 @@ func NewRuleTypeEngine(
 ) (*RuleTypeEngine, error) {
 	if ruletype.Context.GetProject() == "" {
 		return nil, fmt.Errorf("rule type context must have a project")
+	}
+
+	if traits := ruletype.GetDef().GetProviderTraits(); len(traits) > 0 {
+		tp, ok := provider.(traitProvider)
+		if !ok {
+			return nil, fmt.Errorf(
+				"provider does not support trait checks required by rule type %s", ruletype.Name)
+		}
+		for _, trait := range traits {
+			if !tp.CanImplement(trait) {
+				return nil, fmt.Errorf(
+					"provider does not implement required trait %s for rule type %s",
+					trait.String(), ruletype.Name)
+			}
+		}
 	}
 
 	rval, err := profiles.NewRuleValidator(ruletype)

--- a/pkg/engine/v1/rtengine/engine_test.go
+++ b/pkg/engine/v1/rtengine/engine_test.go
@@ -156,3 +156,91 @@ allow if {
 		})
 	}
 }
+
+func TestNewRuleTypeEngineProviderTraits(t *testing.T) {
+	t.Parallel()
+
+	newRuleType := func(traits ...minderv1.ProviderType) *minderv1.RuleType {
+		return &minderv1.RuleType{
+			Name: "test-rule",
+			Context: &minderv1.Context{
+				Project: ptr.Ptr("test"),
+			},
+			Def: &minderv1.RuleType_Definition{
+				InEntity:       minderv1.RepositoryEntity.String(),
+				RuleSchema:     &structpb.Struct{},
+				ProviderTraits: traits,
+				Ingest: &minderv1.RuleType_Definition_Ingest{
+					Type: "git",
+				},
+				Eval: &minderv1.RuleType_Definition_Eval{
+					Type: "rego",
+					Rego: &minderv1.RuleType_Definition_Eval_Rego{
+						Type: "deny-by-default",
+						Def: `package minder
+
+import rego.v1
+
+default allow := false
+`,
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name         string
+		ruleType     *minderv1.RuleType
+		canImplement func(trait minderv1.ProviderType) bool
+		wantErr      bool
+	}{
+		{
+			name:     "no provider_traits is unaffected",
+			ruleType: newRuleType(),
+			canImplement: func(minderv1.ProviderType) bool {
+				return false
+			},
+			wantErr: false,
+		},
+		{
+			name: "provider satisfies all required traits",
+			ruleType: newRuleType(
+				minderv1.ProviderType_PROVIDER_TYPE_GIT,
+				minderv1.ProviderType_PROVIDER_TYPE_GITHUB,
+			),
+			canImplement: func(minderv1.ProviderType) bool {
+				return true
+			},
+			wantErr: false,
+		},
+		{
+			name: "provider missing a required trait",
+			ruleType: newRuleType(
+				minderv1.ProviderType_PROVIDER_TYPE_GIT,
+				minderv1.ProviderType_PROVIDER_TYPE_GITHUB,
+			),
+			canImplement: func(trait minderv1.ProviderType) bool {
+				return trait != minderv1.ProviderType_PROVIDER_TYPE_GITHUB
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tlw := zerolog.NewTestWriter(t)
+			ctx := zerolog.New(tlw).With().Logger().WithContext(context.Background())
+
+			tk := tkv1.NewTestKit(tkv1.WithGitDir(t.TempDir()), tkv1.WithCanImplement(tt.canImplement))
+			_, err := NewRuleTypeEngine(ctx, tt.ruleType, tk)
+			if tt.wantErr {
+				assert.Error(t, err, "NewRuleTypeEngine() should have failed")
+			} else {
+				assert.NoError(t, err, "NewRuleTypeEngine() failed")
+			}
+		})
+	}
+}

--- a/pkg/testkit/v1/testkit.go
+++ b/pkg/testkit/v1/testkit.go
@@ -12,6 +12,8 @@ import (
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-billy/v5/osfs"
+
+	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
 )
 
 // TestKit implements a set of interfaces for testing
@@ -23,6 +25,9 @@ type TestKit struct {
 
 	// HTTP
 	httpHandler http.Handler
+
+	// canImplement backs CanImplement. Defaults to always returning true.
+	canImplement func(trait minderv1.ProviderType) bool
 }
 
 // Option is a functional option type for TestKit
@@ -76,9 +81,19 @@ func WithHTTP(status int, body []byte, headers map[string]string) Option {
 	})
 }
 
+// WithCanImplement is a functional option to control the result of CanImplement.
+// If not set, CanImplement always returns true.
+func WithCanImplement(fn func(trait minderv1.ProviderType) bool) Option {
+	return func(tk *TestKit) {
+		tk.canImplement = fn
+	}
+}
+
 // NewTestKit creates a new TestKit
 func NewTestKit(opts ...Option) *TestKit {
-	pt := &TestKit{}
+	pt := &TestKit{
+		canImplement: func(minderv1.ProviderType) bool { return true },
+	}
 
 	for _, opt := range opts {
 		opt(pt)

--- a/pkg/testkit/v1/testkit_provider.go
+++ b/pkg/testkit/v1/testkit_provider.go
@@ -24,9 +24,9 @@ var (
 var _ provv1.Provider = &TestKit{}
 
 // CanImplement implements the Provider interface.
-// It returns true since we don't have any restrictions on the provider.
-func (*TestKit) CanImplement(_ minderv1.ProviderType) bool {
-	return true
+// By default, it returns true; use WithCanImplement to override for a specific test.
+func (tk *TestKit) CanImplement(trait minderv1.ProviderType) bool {
+	return tk.canImplement(trait)
 }
 
 // FetchAllProperties implements the Provider interface.


### PR DESCRIPTION
## Summary

Widens the gating logic in `NewRuleTypeEngine` so a rule type carrying `provider_traits` (added in #6669) is rejected up front — at engine construction time — if the provider doesn't implement every listed trait. This mirrors the existing pattern used for entity-context mismatches (reject at construction, not via a runtime `ErrEvaluationSkipped`), per the issue.

The trait check is a package-local interface in `pkg/engine/v1/rtengine/engine.go`:

```go
type traitProvider interface {
    CanImplement(trait minderv1.ProviderType) bool
}
```
rather than a new method on pkg/engine/v1/interfaces.Provider. The original design called for widening interfaces.Provider directly, but that creates an import cycle: pkg/engine/v1/interfaces can't import minderv1 because minderv1 (via its hand-written datasources.go) imports pkg/datasources/v1, which imports pkg/engine/v1/interfaces. Declaring traitProvider locally in
rtengine and type-asserting against it avoids the cycle; every concrete provider already implements CanImplement with this exact signature, so they satisfy it structurally with zero provider-side changes.

pkg/testkit/v1.TestKit.CanImplement was hardcoded to always return true; added a WithCanImplement functional option so tests can control it per case, defaulting to true so existing callers (including pkg/ruletest/eval.go) are unaffected.

Part of #6650, closes #6652.

Test plan

- [ ] go build ./pkg/engine/... ./internal/providers/...
- [ ] go test ./pkg/engine/v1/rtengine/... -v
- [ ] gofmt -l on all touched files (clean)