### PR TITLE
feat(github): record remaining API quota gauges

### DIFF
--- a/internal/providers/github/clients/app.go
+++ b/internal/providers/github/clients/app.go
@@ -257,6 +257,8 @@ func (g *GitHubAppDelegate) ListAllRepositories(ctx context.Context) ([]*minderv
 
 		repos, resp, err = g.client.Apps.ListRepos(ctx, listOpt)
 
+		github.ObserveResponseRate(ctx, resp)
+
 		if err != nil {
 			return ghcommon.ConvertRepositories(allRepos), fmt.Errorf("error listing repositories: %w", err)
 		}

--- a/internal/providers/github/clients/oauth.go
+++ b/internal/providers/github/clients/oauth.go
@@ -176,6 +176,8 @@ func (o *GitHubOAuthDelegate) ListAllRepositories(ctx context.Context) ([]*minde
 			repos, resp, err = o.client.Repositories.ListByAuthenticatedUser(ctx, opt)
 		}
 
+		github.ObserveResponseRate(ctx, resp)
+
 		if err != nil {
 			return ghcommon.ConvertRepositories(allRepos), fmt.Errorf("error listing repositories: %w", err)
 		}

--- a/internal/providers/github/common.go
+++ b/internal/providers/github/common.go
@@ -428,6 +428,7 @@ func (c *GitHub) ListFiles(
 	}
 
 	resp, err := performWithRetry(ctx, op)
+	ObserveResponseRate(ctx, resp.resp)
 	return resp.files, resp.resp, err
 }
 
@@ -570,6 +571,8 @@ func (c *GitHub) Do(ctx context.Context, req *http.Request) (*http.Response, err
 	if err != nil && resp == nil {
 		return nil, err
 	}
+
+	ObserveResponseRate(ctx, resp)
 
 	if resp.Response != nil {
 		resp.Body = io.NopCloser(&buf)

--- a/internal/providers/github/rate_metrics.go
+++ b/internal/providers/github/rate_metrics.go
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"context"
+	"sync"
+
+	"github.com/google/go-github/v63/github"
+	"github.com/rs/zerolog"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	rateLimitRemainingMetric = "github.api.ratelimit.remaining"
+	rateLimitLimitMetric     = "github.api.ratelimit.limit"
+)
+
+var (
+	rateMetricsInit sync.Once
+	remainingGauge  metric.Int64Gauge
+	limitGauge      metric.Int64Gauge
+)
+
+func initRateMetrics() {
+	rateMetricsInit.Do(func() {
+		meter := otel.Meter("github")
+		var err error
+		remainingGauge, err = meter.Int64Gauge(
+			rateLimitRemainingMetric,
+			metric.WithDescription("Remaining GitHub API rate limit from github.Response.Rate"),
+			metric.WithUnit("1"),
+		)
+		if err != nil {
+			zerolog.Ctx(context.Background()).Warn().Err(err).Msg("creating GitHub remaining rate-limit gauge failed")
+		}
+		limitGauge, err = meter.Int64Gauge(
+			rateLimitLimitMetric,
+			metric.WithDescription("GitHub API rate limit from github.Response.Rate"),
+			metric.WithUnit("1"),
+		)
+		if err != nil {
+			zerolog.Ctx(context.Background()).Warn().Err(err).Msg("creating GitHub rate-limit gauge failed")
+		}
+	})
+}
+
+// ObserveResponseRate records remaining and limit from a GitHub API response
+// before the provider returns that response to callers. A nil response or an
+// unset Rate (Limit 0) is ignored.
+func ObserveResponseRate(ctx context.Context, resp *github.Response) {
+	initRateMetrics()
+	observeResponseRate(ctx, remainingGauge, limitGauge, resp)
+}
+
+func observeResponseRate(
+	ctx context.Context,
+	remaining metric.Int64Gauge,
+	limit metric.Int64Gauge,
+	resp *github.Response,
+) {
+	if resp == nil || resp.Rate.Limit == 0 {
+		return
+	}
+	if remaining != nil {
+		remaining.Record(ctx, int64(resp.Rate.Remaining))
+	}
+	if limit != nil {
+		limit.Record(ctx, int64(resp.Rate.Limit))
+	}
+}

--- a/internal/providers/github/rate_metrics_test.go
+++ b/internal/providers/github/rate_metrics_test.go
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-github/v63/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestObserveResponseRate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		resp            *github.Response
+		expectRemaining *int64
+		expectLimit     *int64
+	}{
+		{
+			name: "populated rate",
+			resp: &github.Response{
+				Rate: github.Rate{Remaining: 4500, Limit: 5000},
+			},
+			expectRemaining: int64Ptr(4500),
+			expectLimit:     int64Ptr(5000),
+		},
+		{
+			name:            "nil response",
+			resp:            nil,
+			expectRemaining: nil,
+			expectLimit:     nil,
+		},
+		{
+			name:            "unset rate",
+			resp:            &github.Response{},
+			expectRemaining: nil,
+			expectLimit:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			reader := sdkmetric.NewManualReader()
+			mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+			t.Cleanup(func() {
+				require.NoError(t, mp.Shutdown(context.Background()))
+			})
+
+			meter := mp.Meter("github")
+			remaining, err := meter.Int64Gauge(rateLimitRemainingMetric)
+			require.NoError(t, err)
+			limit, err := meter.Int64Gauge(rateLimitLimitMetric)
+			require.NoError(t, err)
+
+			observeResponseRate(context.Background(), remaining, limit, tt.resp)
+
+			var rm metricdata.ResourceMetrics
+			require.NoError(t, reader.Collect(context.Background(), &rm))
+
+			gotRemaining, gotLimit := gaugeValues(t, rm)
+			if tt.expectRemaining == nil {
+				assert.Nil(t, gotRemaining, "remaining gauge should not be recorded")
+			} else {
+				require.NotNil(t, gotRemaining)
+				assert.Equal(t, *tt.expectRemaining, *gotRemaining)
+			}
+			if tt.expectLimit == nil {
+				assert.Nil(t, gotLimit, "limit gauge should not be recorded")
+			} else {
+				require.NotNil(t, gotLimit)
+				assert.Equal(t, *tt.expectLimit, *gotLimit)
+			}
+		})
+	}
+}
+
+func int64Ptr(v int64) *int64 {
+	return &v
+}
+
+func gaugeValues(t *testing.T, rm metricdata.ResourceMetrics) (remaining *int64, limit *int64) {
+	t.Helper()
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			data, ok := m.Data.(metricdata.Gauge[int64])
+			if !ok || len(data.DataPoints) == 0 {
+				continue
+			}
+			val := data.DataPoints[0].Value
+			switch m.Name {
+			case rateLimitRemainingMetric:
+				remaining = &val
+			case rateLimitLimitMetric:
+				limit = &val
+			}
+		}
+	}
+	return remaining, limit
+}
+
+// Ensure the public helper does not panic when gauges are uninitialized in tests.
+func TestObserveResponseRatePublicNilSafe(t *testing.T) {
+	t.Parallel()
+	ObserveResponseRate(context.Background(), nil)
+	ObserveResponseRate(context.Background(), &github.Response{})
+}


### PR DESCRIPTION
## Summary
- Record `github.Response.Rate.Remaining` and `Rate.Limit` as OpenTelemetry gauges (`github.api.ratelimit.remaining`, `github.api.ratelimit.limit`) before the GitHub provider returns those responses.
- Observe at `ListFiles`, `GitHub.Do`, and `ListAllRepositories` (OAuth and App). These already hold `*github.Response` and cover PR diffs, REST rules, and repository registration.
- Use gauges rather than counters because summing remaining quota across calls is not useful. The existing HTTP RoundTripper histogram (`github.http.ratelimit.remaining`) is unchanged.

Fixes #5124

Follow-ups if useful: `ClientServiceImplementation` (installations and membership) and other call sites that currently discard `*github.Response`.

## Test plan
- [x] `go test ./internal/providers/github/ ./internal/providers/github/clients/`
- [x] Confirm gauges appear after a `ListFiles` or repo-list call against a live GitHub token (remaining and limit last-value)


Made with [Cursor](https://cursor.com)