### PR TITLE
fix(gitlab): request project license with ?license=true

### DIFF
--- a/internal/providers/gitlab/repository_properties.go
+++ b/internal/providers/gitlab/repository_properties.go
@@ -58,7 +58,8 @@ func (c *gitlabClient) getGitLabProject(
 	// request here because of the way they form authentication for requests.
 	// It would be ideal to use it, so we should consider contributing and making
 	// that part more pluggable.
-	req, err := c.NewRequest("GET", projectURLPath, nil)
+	// GitLab omits license unless license=true is requested.
+	req, err := c.NewRequest("GET", projectURLPath+"?license=true", nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}


### PR DESCRIPTION
## Summary

fix(gitlab): request project license with ?license=true

## Changes

- GitLab omits license unless license=true is set on GET /projects/:id.
- Append the query so RepoPropertyLicense is populated.

Fixes #6589
