### PR TITLE
fix(gitlab): request project license from the API

### DIFF
--- a/internal/providers/gitlab/properties_test.go
+++ b/internal/providers/gitlab/properties_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -386,6 +387,45 @@ func TestPropertiesToProtoMessage(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func Test_gitlabClient_getGitLabProject_requestsLicense(t *testing.T) {
+	t.Parallel()
+
+	var gotQuery url.Values
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+
+		resp := &gitlab.Project{
+			ID:   1,
+			Name: "project-1",
+			Namespace: &gitlab.ProjectNamespace{
+				Path: "group",
+			},
+			License: &gitlab.ProjectLicense{
+				Key:  "mit",
+				Name: "MIT License",
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		//nolint:gosec // This is a test
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	got, err := newTestGitlabProvider(ts.URL).getPropertiesForRepo(
+		context.Background(),
+		properties.NewProperties(map[string]any{
+			properties.PropertyUpstreamID: "1",
+		}),
+	)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "true", gotQuery.Get("license"),
+		"GitLab omits license information unless license=true is requested")
+	assert.Equal(t, "MIT License", got.GetProperty(RepoPropertyLicense).GetString())
 }
 
 func newTestGitlabProvider(endpoint string) *gitlabClient {

--- a/internal/providers/gitlab/repository_properties.go
+++ b/internal/providers/gitlab/repository_properties.go
@@ -54,6 +54,9 @@ func (c *gitlabClient) getGitLabProject(
 		return nil, fmt.Errorf("failed to join URL path for project using upstream ID: %w", err)
 	}
 
+	// GitLab only includes the project's license in the response when explicitly asked for it
+	projectURLPath += "?" + url.Values{"license": []string{"true"}}.Encode()
+
 	// NOTE: We're not using github.com/xanzy/go-gitlab to do the actual
 	// request here because of the way they form authentication for requests.
 	// It would be ideal to use it, so we should consider contributing and making


### PR DESCRIPTION
Fixes #6589

`getGitLabProject()` builds the request path as `projects/<id>` with no query
string. GitLab only populates the `license` field on the project payload when
`license=true` is passed, so `RepoPropertyLicense` (`gitlab/license`) was always
empty.

This appends `license=true` to the project request. `NewRequest` -> `getParsedURL`
already parses path and query separately and copies `RawQuery` onto the final URL,
so no change is needed in the REST layer.

`getGitLabProject()` is also called from `pull_request_properties.go` and
`release_properties.go`, so those entity fetches pick up license data as well.

Adds a regression test asserting the outgoing request carries `license=true` and
that `RepoPropertyLicense` is populated from the response.