### PR TITLE
docs: document provider_traits for rule type authors

### DIFF
--- a/docs/docs/ref/formats/ruletype.mdx
+++ b/docs/docs/ref/formats/ruletype.mdx
@@ -26,6 +26,7 @@ severity:
   value: high
 def:
   in_entity: repository
+  provider_traits: ["rest", "github"]
   rule_schema: {}
   ingest:
     type: rest
@@ -53,7 +54,7 @@ The Minder CLI will parse rego files and extract RuleType metadata from them.  I
 | --- | --- |
 | `name` | populate from filename if not present |
 | `display_name` | populate from `title` if not present |
-| `def.rule_schemad` | defaults to empty-object |
+| `def.rule_schema` | defaults to empty-object |
 
 ```rego
 # METADATA
@@ -84,6 +85,23 @@ input.ingested.enforce_admins.enabled == true
 input.ingested.allow_force_pushes == false
 input.ingested.allow_deletions == false
 ```
+
+## Provider traits
+
+`provider_traits` is an optional list on `def` that declares which provider capabilities a rule type depends on. Minder only evaluates the rule against providers that implement every listed trait:
+
+```yaml
+def:
+  provider_traits: ["rest", "github"]
+```
+
+The valid trait names are `git`, `github`, `gitlab`, `image-lister`, `oci`, `repo-lister`, and `rest`. Traits are ANDed together: a rule type requiring `["git", "github"]` needs a provider that implements both, not just one. The canonical idiom is `["rest", "github"]` for a rule that calls the GitHub API, and `["rest", "gitlab"]` for the GitLab equivalent. Omitting the field, or leaving it empty, means the rule type is not gated and evaluates against any provider.
+
+:::note
+If a provider doesn't implement a rule type's declared traits, the rule produces no evaluation result for that provider at all — it isn't listed, skipped, or errored, it simply doesn't appear in `minder profile status list`. A rule that can't apply to a provider isn't a finding.
+
+An unrecognized trait name is different: it's rejected at `ruletype create` with the valid values listed in the error message, and if one is already stored, evaluation records an error status naming the offending trait.
+:::
 
 ## Fields
 


### PR DESCRIPTION
Closes #6654.

`provider_traits` shipped in #6702 but has no prose documentation. The field's own description already renders in the Fields section via `<ApiSchema>` from the proto comment, so this covers only what a schema dump can't express.

Adds a `## Provider traits` section to the rule type format reference covering:

- AND semantics — every listed trait must be implemented, not just one
- The valid trait names
- The `["rest", "github"]` / `["rest", "gitlab"]` idiom for rules that call a provider-specific API
- That omitting the field leaves the rule type ungated

The part authors are most likely to be caught out by is in a `:::note`: a rule type whose declared traits the provider doesn't implement produces **no evaluation result at all** — it isn't listed, skipped, or errored, it simply doesn't appear in `minder profile status list`. That's deliberate (a rule that can't apply to a provider isn't a finding), but it's invisible, so a profile can list a rule that never shows up in its results. The note also distinguishes that from an unrecognized trait name, which is rejected at `ruletype create`.

Also adds `provider_traits` to the YAML example so it appears in context, and fixes a typo in the Rego field promotion table (`def.rule_schemad` → `def.rule_schema`).

### Test plan

- [ ] `cd docs && npm start` — Provider traits section renders, admonition displays as a note rather than literal `:::`, field promotion table still renders as a table