### PR TITLE
Simplify spacing requirements for rego format

### DIFF
--- a/pkg/fileconvert/rego_parser.go
+++ b/pkg/fileconvert/rego_parser.go
@@ -98,8 +98,10 @@ func (r *regoDecoder) Decode(v any) error {
 }
 
 // metadataExtractor extracts the YAML document
-var metadataExtractor = regexp.MustCompile("(?m)^# +METADATA *\r?\n((?:#(?: [^\n]*)?\n)+)")
-var removeCommentPrefix = regexp.MustCompile("(?m)^# ")
+var (
+	metadataExtractor   = regexp.MustCompile("(?m)^# +METADATA *\r?\n((?:#(?: [^\r\n]*)?\r?\n)+)")
+	removeCommentPrefix = regexp.MustCompile("(?m)^# ?") // default greedy
+)
 
 // OPA uses YAML metadata inside a specially-headered comment.  Extracting
 // the metadata requires finding the comment block, then stripping the comment


### PR DESCRIPTION
# Summary



Currently, `mindev test` (particularly on Windows) is very picky about rego format files.  (It requires at least one space even on blank comment lines.)  Handle windows newlines in body correctly and accept completely-empty comment lines (which otherwise break multi-paragraph guidance and other text blocks).



# Testing



Tested manually while converting rules to Rego using the pattern:



1. ***Relocate rego to end of file, remove indents***
2. ***Comment entire previous file***
3. ***Add `# METADATA` comment***
4. ***Remove unnecessary entries (`apiVersion`, `type`, `name`, `def.eval.rego.def`, etc)***

