### PR TITLE
Add gitlab to the provider_type enum and report it in SupportedProviderTypes

### DIFF
--- a/database/migrations/000118_gitlab_provider_type.down.sql
+++ b/database/migrations/000118_gitlab_provider_type.down.sql
@@ -1,0 +1,6 @@
+-- SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Postgres can't remove a value for an enum type. So, we can't really
+-- do a down migration. Instead, we'll just leave this here as a
+-- reminder that we can't remove this value.

--- a/database/migrations/000118_gitlab_provider_type.up.sql
+++ b/database/migrations/000118_gitlab_provider_type.up.sql
@@ -1,0 +1,8 @@
+-- SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Add `gitlab` provider type, so that a registered GitLab provider's
+-- `implements` column can record that it supports the `gitlab` trait,
+-- matching what `provifv1.Provider.CanImplement` already gates at
+-- evaluation time.
+ALTER TYPE provider_type ADD VALUE 'gitlab';

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -294,6 +294,7 @@ const (
 	ProviderTypeOci         ProviderType = "oci"
 	ProviderTypeRepoLister  ProviderType = "repo-lister"
 	ProviderTypeImageLister ProviderType = "image-lister"
+	ProviderTypeGitlab      ProviderType = "gitlab"
 )
 
 func (e *ProviderType) Scan(src interface{}) error {

--- a/internal/providers/github/mock/github.go
+++ b/internal/providers/github/mock/github.go
@@ -2241,6 +2241,248 @@ func (mr *MockGitHubMockRecorder) UpdateReview(arg0, arg1, arg2, arg3, arg4, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateReview", reflect.TypeOf((*MockGitHub)(nil).UpdateReview), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
+// MockGitLab is a mock of GitLab interface.
+type MockGitLab struct {
+	ctrl     *gomock.Controller
+	recorder *MockGitLabMockRecorder
+	isgomock struct{}
+}
+
+// MockGitLabMockRecorder is the mock recorder for MockGitLab.
+type MockGitLabMockRecorder struct {
+	mock *MockGitLab
+}
+
+// NewMockGitLab creates a new mock instance.
+func NewMockGitLab(ctrl *gomock.Controller) *MockGitLab {
+	mock := &MockGitLab{ctrl: ctrl}
+	mock.recorder = &MockGitLabMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockGitLab) EXPECT() *MockGitLabMockRecorder {
+	return m.recorder
+}
+
+// CanImplement mocks base method.
+func (m *MockGitLab) CanImplement(trait v10.ProviderType) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CanImplement", trait)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// CanImplement indicates an expected call of CanImplement.
+func (mr *MockGitLabMockRecorder) CanImplement(trait any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanImplement", reflect.TypeOf((*MockGitLab)(nil).CanImplement), trait)
+}
+
+// Clone mocks base method.
+func (m *MockGitLab) Clone(ctx context.Context, url, branch string) (*git.Repository, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Clone", ctx, url, branch)
+	ret0, _ := ret[0].(*git.Repository)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Clone indicates an expected call of Clone.
+func (mr *MockGitLabMockRecorder) Clone(ctx, url, branch any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockGitLab)(nil).Clone), ctx, url, branch)
+}
+
+// CreationOptions mocks base method.
+func (m *MockGitLab) CreationOptions(entType v10.Entity) *v11.EntityCreationOptions {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreationOptions", entType)
+	ret0, _ := ret[0].(*v11.EntityCreationOptions)
+	return ret0
+}
+
+// CreationOptions indicates an expected call of CreationOptions.
+func (mr *MockGitLabMockRecorder) CreationOptions(entType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreationOptions", reflect.TypeOf((*MockGitLab)(nil).CreationOptions), entType)
+}
+
+// DeregisterEntity mocks base method.
+func (m *MockGitLab) DeregisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeregisterEntity", ctx, entType, props)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeregisterEntity indicates an expected call of DeregisterEntity.
+func (mr *MockGitLabMockRecorder) DeregisterEntity(ctx, entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterEntity", reflect.TypeOf((*MockGitLab)(nil).DeregisterEntity), ctx, entType, props)
+}
+
+// Do mocks base method.
+func (m *MockGitLab) Do(ctx context.Context, req *http.Request) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Do", ctx, req)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Do indicates an expected call of Do.
+func (mr *MockGitLabMockRecorder) Do(ctx, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Do", reflect.TypeOf((*MockGitLab)(nil).Do), ctx, req)
+}
+
+// FetchAllProperties mocks base method.
+func (m *MockGitLab) FetchAllProperties(ctx context.Context, getByProps *properties.Properties, entType v10.Entity, cachedProps *properties.Properties) (*properties.Properties, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, getByProps, entType, cachedProps)
+	ret0, _ := ret[0].(*properties.Properties)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FetchAllProperties indicates an expected call of FetchAllProperties.
+func (mr *MockGitLabMockRecorder) FetchAllProperties(ctx, getByProps, entType, cachedProps any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockGitLab)(nil).FetchAllProperties), ctx, getByProps, entType, cachedProps)
+}
+
+// GetBaseURL mocks base method.
+func (m *MockGitLab) GetBaseURL() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBaseURL")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetBaseURL indicates an expected call of GetBaseURL.
+func (mr *MockGitLabMockRecorder) GetBaseURL() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBaseURL", reflect.TypeOf((*MockGitLab)(nil).GetBaseURL))
+}
+
+// GetCredential mocks base method.
+func (m *MockGitLab) GetCredential() v11.GitLabCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCredential")
+	ret0, _ := ret[0].(v11.GitLabCredential)
+	return ret0
+}
+
+// GetCredential indicates an expected call of GetCredential.
+func (mr *MockGitLabMockRecorder) GetCredential() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCredential", reflect.TypeOf((*MockGitLab)(nil).GetCredential))
+}
+
+// GetEntityName mocks base method.
+func (m *MockGitLab) GetEntityName(entType v10.Entity, props *properties.Properties) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEntityName", entType, props)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEntityName indicates an expected call of GetEntityName.
+func (mr *MockGitLabMockRecorder) GetEntityName(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityName", reflect.TypeOf((*MockGitLab)(nil).GetEntityName), entType, props)
+}
+
+// ListAllRepositories mocks base method.
+func (m *MockGitLab) ListAllRepositories(arg0 context.Context) ([]*v10.Repository, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAllRepositories", arg0)
+	ret0, _ := ret[0].([]*v10.Repository)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAllRepositories indicates an expected call of ListAllRepositories.
+func (mr *MockGitLabMockRecorder) ListAllRepositories(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllRepositories", reflect.TypeOf((*MockGitLab)(nil).ListAllRepositories), arg0)
+}
+
+// NewRequest mocks base method.
+func (m *MockGitLab) NewRequest(method, url string, body any) (*http.Request, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewRequest", method, url, body)
+	ret0, _ := ret[0].(*http.Request)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NewRequest indicates an expected call of NewRequest.
+func (mr *MockGitLabMockRecorder) NewRequest(method, url, body any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRequest", reflect.TypeOf((*MockGitLab)(nil).NewRequest), method, url, body)
+}
+
+// PropertiesToProtoMessage mocks base method.
+func (m *MockGitLab) PropertiesToProtoMessage(entType v10.Entity, props *properties.Properties) (protoreflect.ProtoMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PropertiesToProtoMessage", entType, props)
+	ret0, _ := ret[0].(protoreflect.ProtoMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PropertiesToProtoMessage indicates an expected call of PropertiesToProtoMessage.
+func (mr *MockGitLabMockRecorder) PropertiesToProtoMessage(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PropertiesToProtoMessage", reflect.TypeOf((*MockGitLab)(nil).PropertiesToProtoMessage), entType, props)
+}
+
+// ProviderClassInfo mocks base method.
+func (m *MockGitLab) ProviderClassInfo() *v10.ProviderClassInfo {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ProviderClassInfo")
+	ret0, _ := ret[0].(*v10.ProviderClassInfo)
+	return ret0
+}
+
+// ProviderClassInfo indicates an expected call of ProviderClassInfo.
+func (mr *MockGitLabMockRecorder) ProviderClassInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProviderClassInfo", reflect.TypeOf((*MockGitLab)(nil).ProviderClassInfo))
+}
+
+// RegisterEntity mocks base method.
+func (m *MockGitLab) RegisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) (*properties.Properties, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RegisterEntity", ctx, entType, props)
+	ret0, _ := ret[0].(*properties.Properties)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RegisterEntity indicates an expected call of RegisterEntity.
+func (mr *MockGitLabMockRecorder) RegisterEntity(ctx, entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterEntity", reflect.TypeOf((*MockGitLab)(nil).RegisterEntity), ctx, entType, props)
+}
+
+// SupportsEntity mocks base method.
+func (m *MockGitLab) SupportsEntity(entType v10.Entity) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SupportsEntity", entType)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// SupportsEntity indicates an expected call of SupportsEntity.
+func (mr *MockGitLabMockRecorder) SupportsEntity(entType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsEntity", reflect.TypeOf((*MockGitLab)(nil).SupportsEntity), entType)
+}
+
 // MockImageLister is a mock of ImageLister interface.
 type MockImageLister struct {
 	ctrl     *gomock.Controller

--- a/internal/providers/gitlab/gitlab.go
+++ b/internal/providers/gitlab/gitlab.go
@@ -38,6 +38,7 @@ var AuthorizationFlows = []db.AuthorizationFlow{
 var _ provifv1.Git = (*gitlabClient)(nil)
 var _ provifv1.REST = (*gitlabClient)(nil)
 var _ provifv1.RepoLister = (*gitlabClient)(nil)
+var _ provifv1.GitLab = (*gitlabClient)(nil)
 
 type gitlabClient struct {
 	cred       provifv1.GitLabCredential

--- a/internal/providers/gitlab/metadata_test.go
+++ b/internal/providers/gitlab/metadata_test.go
@@ -38,5 +38,6 @@ func TestClassInfo(t *testing.T) {
 		minderv1.ProviderType_PROVIDER_TYPE_GIT,
 		minderv1.ProviderType_PROVIDER_TYPE_REST,
 		minderv1.ProviderType_PROVIDER_TYPE_REPO_LISTER,
+		minderv1.ProviderType_PROVIDER_TYPE_GITLAB,
 	}, info.SupportedProviderTypes)
 }

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -55,6 +55,8 @@ func DBToPBType(t db.ProviderType) (minderv1.ProviderType, bool) {
 		return minderv1.ProviderType_PROVIDER_TYPE_OCI, true
 	case db.ProviderTypeImageLister:
 		return minderv1.ProviderType_PROVIDER_TYPE_IMAGE_LISTER, true
+	case db.ProviderTypeGitlab:
+		return minderv1.ProviderType_PROVIDER_TYPE_GITLAB, true
 	default:
 		return minderv1.ProviderType_PROVIDER_TYPE_UNSPECIFIED, false
 	}
@@ -76,12 +78,7 @@ func PBToDBType(t minderv1.ProviderType) (db.ProviderType, bool) {
 	case minderv1.ProviderType_PROVIDER_TYPE_IMAGE_LISTER:
 		return db.ProviderTypeImageLister, true
 	case minderv1.ProviderType_PROVIDER_TYPE_GITLAB:
-		// PROVIDER_TYPE_GITLAB exists as a rule type provider_traits value
-		// only; it is gated at evaluation time through
-		// provifv1.Provider.CanImplement, not through the providers table.
-		// There is deliberately no 'gitlab' value in the provider_type
-		// database enum, so it has no db.ProviderType to map to.
-		return db.ProviderType(""), false
+		return db.ProviderTypeGitlab, true
 	case minderv1.ProviderType_PROVIDER_TYPE_UNSPECIFIED:
 		return db.ProviderType(""), false
 	default:

--- a/pkg/providers/v1/mock/providers.go
+++ b/pkg/providers/v1/mock/providers.go
@@ -2241,6 +2241,248 @@ func (mr *MockGitHubMockRecorder) UpdateReview(arg0, arg1, arg2, arg3, arg4, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateReview", reflect.TypeOf((*MockGitHub)(nil).UpdateReview), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
+// MockGitLab is a mock of GitLab interface.
+type MockGitLab struct {
+	ctrl     *gomock.Controller
+	recorder *MockGitLabMockRecorder
+	isgomock struct{}
+}
+
+// MockGitLabMockRecorder is the mock recorder for MockGitLab.
+type MockGitLabMockRecorder struct {
+	mock *MockGitLab
+}
+
+// NewMockGitLab creates a new mock instance.
+func NewMockGitLab(ctrl *gomock.Controller) *MockGitLab {
+	mock := &MockGitLab{ctrl: ctrl}
+	mock.recorder = &MockGitLabMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockGitLab) EXPECT() *MockGitLabMockRecorder {
+	return m.recorder
+}
+
+// CanImplement mocks base method.
+func (m *MockGitLab) CanImplement(trait v10.ProviderType) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CanImplement", trait)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// CanImplement indicates an expected call of CanImplement.
+func (mr *MockGitLabMockRecorder) CanImplement(trait any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanImplement", reflect.TypeOf((*MockGitLab)(nil).CanImplement), trait)
+}
+
+// Clone mocks base method.
+func (m *MockGitLab) Clone(ctx context.Context, url, branch string) (*git.Repository, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Clone", ctx, url, branch)
+	ret0, _ := ret[0].(*git.Repository)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Clone indicates an expected call of Clone.
+func (mr *MockGitLabMockRecorder) Clone(ctx, url, branch any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockGitLab)(nil).Clone), ctx, url, branch)
+}
+
+// CreationOptions mocks base method.
+func (m *MockGitLab) CreationOptions(entType v10.Entity) *v11.EntityCreationOptions {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreationOptions", entType)
+	ret0, _ := ret[0].(*v11.EntityCreationOptions)
+	return ret0
+}
+
+// CreationOptions indicates an expected call of CreationOptions.
+func (mr *MockGitLabMockRecorder) CreationOptions(entType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreationOptions", reflect.TypeOf((*MockGitLab)(nil).CreationOptions), entType)
+}
+
+// DeregisterEntity mocks base method.
+func (m *MockGitLab) DeregisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeregisterEntity", ctx, entType, props)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeregisterEntity indicates an expected call of DeregisterEntity.
+func (mr *MockGitLabMockRecorder) DeregisterEntity(ctx, entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterEntity", reflect.TypeOf((*MockGitLab)(nil).DeregisterEntity), ctx, entType, props)
+}
+
+// Do mocks base method.
+func (m *MockGitLab) Do(ctx context.Context, req *http.Request) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Do", ctx, req)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Do indicates an expected call of Do.
+func (mr *MockGitLabMockRecorder) Do(ctx, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Do", reflect.TypeOf((*MockGitLab)(nil).Do), ctx, req)
+}
+
+// FetchAllProperties mocks base method.
+func (m *MockGitLab) FetchAllProperties(ctx context.Context, getByProps *properties.Properties, entType v10.Entity, cachedProps *properties.Properties) (*properties.Properties, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, getByProps, entType, cachedProps)
+	ret0, _ := ret[0].(*properties.Properties)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FetchAllProperties indicates an expected call of FetchAllProperties.
+func (mr *MockGitLabMockRecorder) FetchAllProperties(ctx, getByProps, entType, cachedProps any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockGitLab)(nil).FetchAllProperties), ctx, getByProps, entType, cachedProps)
+}
+
+// GetBaseURL mocks base method.
+func (m *MockGitLab) GetBaseURL() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBaseURL")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetBaseURL indicates an expected call of GetBaseURL.
+func (mr *MockGitLabMockRecorder) GetBaseURL() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBaseURL", reflect.TypeOf((*MockGitLab)(nil).GetBaseURL))
+}
+
+// GetCredential mocks base method.
+func (m *MockGitLab) GetCredential() v11.GitLabCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCredential")
+	ret0, _ := ret[0].(v11.GitLabCredential)
+	return ret0
+}
+
+// GetCredential indicates an expected call of GetCredential.
+func (mr *MockGitLabMockRecorder) GetCredential() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCredential", reflect.TypeOf((*MockGitLab)(nil).GetCredential))
+}
+
+// GetEntityName mocks base method.
+func (m *MockGitLab) GetEntityName(entType v10.Entity, props *properties.Properties) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEntityName", entType, props)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEntityName indicates an expected call of GetEntityName.
+func (mr *MockGitLabMockRecorder) GetEntityName(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityName", reflect.TypeOf((*MockGitLab)(nil).GetEntityName), entType, props)
+}
+
+// ListAllRepositories mocks base method.
+func (m *MockGitLab) ListAllRepositories(arg0 context.Context) ([]*v10.Repository, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAllRepositories", arg0)
+	ret0, _ := ret[0].([]*v10.Repository)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAllRepositories indicates an expected call of ListAllRepositories.
+func (mr *MockGitLabMockRecorder) ListAllRepositories(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllRepositories", reflect.TypeOf((*MockGitLab)(nil).ListAllRepositories), arg0)
+}
+
+// NewRequest mocks base method.
+func (m *MockGitLab) NewRequest(method, url string, body any) (*http.Request, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewRequest", method, url, body)
+	ret0, _ := ret[0].(*http.Request)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NewRequest indicates an expected call of NewRequest.
+func (mr *MockGitLabMockRecorder) NewRequest(method, url, body any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRequest", reflect.TypeOf((*MockGitLab)(nil).NewRequest), method, url, body)
+}
+
+// PropertiesToProtoMessage mocks base method.
+func (m *MockGitLab) PropertiesToProtoMessage(entType v10.Entity, props *properties.Properties) (protoreflect.ProtoMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PropertiesToProtoMessage", entType, props)
+	ret0, _ := ret[0].(protoreflect.ProtoMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PropertiesToProtoMessage indicates an expected call of PropertiesToProtoMessage.
+func (mr *MockGitLabMockRecorder) PropertiesToProtoMessage(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PropertiesToProtoMessage", reflect.TypeOf((*MockGitLab)(nil).PropertiesToProtoMessage), entType, props)
+}
+
+// ProviderClassInfo mocks base method.
+func (m *MockGitLab) ProviderClassInfo() *v10.ProviderClassInfo {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ProviderClassInfo")
+	ret0, _ := ret[0].(*v10.ProviderClassInfo)
+	return ret0
+}
+
+// ProviderClassInfo indicates an expected call of ProviderClassInfo.
+func (mr *MockGitLabMockRecorder) ProviderClassInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProviderClassInfo", reflect.TypeOf((*MockGitLab)(nil).ProviderClassInfo))
+}
+
+// RegisterEntity mocks base method.
+func (m *MockGitLab) RegisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) (*properties.Properties, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RegisterEntity", ctx, entType, props)
+	ret0, _ := ret[0].(*properties.Properties)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RegisterEntity indicates an expected call of RegisterEntity.
+func (mr *MockGitLabMockRecorder) RegisterEntity(ctx, entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterEntity", reflect.TypeOf((*MockGitLab)(nil).RegisterEntity), ctx, entType, props)
+}
+
+// SupportsEntity mocks base method.
+func (m *MockGitLab) SupportsEntity(entType v10.Entity) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SupportsEntity", entType)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// SupportsEntity indicates an expected call of SupportsEntity.
+func (mr *MockGitLabMockRecorder) SupportsEntity(entType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsEntity", reflect.TypeOf((*MockGitLab)(nil).SupportsEntity), entType)
+}
+
 // MockImageLister is a mock of ImageLister interface.
 type MockImageLister struct {
 	ctrl     *gomock.Controller

--- a/pkg/providers/v1/providers.go
+++ b/pkg/providers/v1/providers.go
@@ -297,6 +297,17 @@ type GitHub interface {
 	UpdateCheckRun(context.Context, string, string, int64, *github.UpdateCheckRunOptions) (*github.CheckRun, error)
 }
 
+// GitLab is the interface for interacting with the GitLab REST API
+// Add methods here for interacting with the GitLab REST API
+type GitLab interface {
+	Provider
+	RepoLister
+	REST
+	Git
+
+	GetCredential() GitLabCredential
+}
+
 // ImageLister is the interface for listing images
 type ImageLister interface {
 	Provider
@@ -352,6 +363,7 @@ func ParseAndValidate(rawConfig json.RawMessage, to any) error {
 // must implement to support it.
 var providerTypeMap = map[minderv1.ProviderType]reflect.Type{
 	minderv1.ProviderType_PROVIDER_TYPE_GITHUB:       reflect.TypeOf((*GitHub)(nil)).Elem(),
+	minderv1.ProviderType_PROVIDER_TYPE_GITLAB:       reflect.TypeOf((*GitLab)(nil)).Elem(),
 	minderv1.ProviderType_PROVIDER_TYPE_REST:         reflect.TypeOf((*REST)(nil)).Elem(),
 	minderv1.ProviderType_PROVIDER_TYPE_GIT:          reflect.TypeOf((*Git)(nil)).Elem(),
 	minderv1.ProviderType_PROVIDER_TYPE_OCI:          reflect.TypeOf((*OCI)(nil)).Elem(),


### PR DESCRIPTION
Follow-up to #6702, discussed with @evankanderson.

#6702 added a `gitlab` provider trait so rule types can declare `provider_traits: ["rest", "gitlab"]`. Rule gating works, because it goes through `provifv1.Provider.CanImplement`, which the GitLab client implements. But the persisted side was left behind: `db.Provider.Implements` is populated from `ProviderClassInfo.SupportedProviderTypes`, which `ProviderTypesFromImpl` derives by reflection against `providerTypeMap` — a map of `ProviderType` to Go interface. With no `provifv1.GitLab` interface, there was no entry, so `minder provider get` never listed `gitlab` under Implements even though gating honoured it.

This closes that gap:

- Adds `provifv1.GitLab` (`Provider` + `RepoLister` + `REST` + `Git`, plus `GetCredential() GitLabCredential`). The credential method is what makes it discriminating — no other provider client returns `GitLabCredential`, so nothing else accidentally satisfies the interface.
- Adds the `providerTypeMap` entry and a compile-time assertion on `gitlabClient`.
- Migration `000118` adds `gitlab` to the `provider_type` Postgres enum, following the pattern of `000002` and `000055`. The down migration is a no-op, as those are — Postgres has no `DROP VALUE`.
- `PBToDBType` now maps the trait to `db.ProviderTypeGitlab` instead of returning no DB equivalent, and `DBToPBType` gains the symmetric case so a persisted `gitlab` trait isn't dropped on read.

### Not included: backfill

A new enum value doesn't retroactively update existing `providers.implements` rows, so GitLab providers registered before this will still show `{git, rest, repo-lister}`. I didn't write a backfill migration because nothing currently queries `implements` for `gitlab` — every `GetByTraitInHierarchy` / `BulkInstantiateByTrait` caller is hardcoded to `github` or `repo-lister`, and rule-type gating uses the live provider instance rather than this column. So the only effect today is `provider get` under-reporting for pre-existing rows. Happy to add one if you'd rather.

### Test plan

- [x] `make sqlc` — `db.ProviderTypeGitlab` generated
- [x] `go build ./...`
- [x] `go test ./pkg/providers/... ./internal/providers/... ./internal/engine/... ./pkg/engine/... ./internal/controlplane/...`
- [ ] Migration applied against a local Postgres