### PR TITLE
Add coverage tracking for `mindev test`

### DIFF
--- a/cmd/dev/app/test/test.go
+++ b/cmd/dev/app/test/test.go
@@ -68,10 +68,12 @@ func CmdTest() *cobra.Command {
 				}
 			}
 
-			for _, res := range results {
-				if len(res.Failures) > 0 {
-					finalErr = errors.New("one or more tests failed")
-					break
+			for _, run := range results {
+				for _, res := range run.Results {
+					if len(res.Failures)+len(res.Errors) > 0 {
+						finalErr = errors.New("one or more tests failed")
+						break
+					}
 				}
 			}
 			return finalErr
@@ -80,27 +82,44 @@ func CmdTest() *cobra.Command {
 
 	cmd.Flags().StringVarP(&outputFormat, "output", "o", "text", "Output format (text, junit)")
 	cmd.Flags().StringVar(&junitFile, "junit-file", "", "File to write JUnit report to (in addition to standard output)")
+	cmd.Flags().Bool("coverage", false, "Show uncovered rules in the output")
 
 	return cmd
 }
 
-func formatFailuresHuman(cmd *cobra.Command, results []ruletest.TestResult) {
+func formatFailuresHuman(cmd *cobra.Command, results []ruletest.TestRun) {
 	if len(results) == 0 {
 		cmd.Printf("No tests found\n")
 	}
-	for _, res := range results {
-		if len(res.Failures) > 0 {
-			cmd.Printf("FAIL: %s/%s\n", res.Filename, res.Name)
-			for _, f := range res.Failures {
-				cmd.Printf("  - %s\n", f)
+	coverage, _ := cmd.Flags().GetBool("coverage")
+	for _, run := range results {
+		cmd.Printf("Test run in %s:\n", run.BaseDir)
+		for _, res := range run.Results {
+			if len(res.Failures) > 0 {
+				cmd.Printf("FAIL: %s/%s\n", res.Filename, res.Name)
+				for _, f := range res.Failures {
+					cmd.Printf("  - %s\n", f)
+				}
+			} else if len(res.Errors) > 0 {
+				cmd.Printf("ERROR: %s/%s\n", res.Filename, res.Name)
+				for _, e := range res.Errors {
+					cmd.Printf("  - %s\n", e)
+				}
+			} else {
+				cmd.Printf("PASS: %s/%s\n", res.Filename, res.Name)
 			}
-		} else {
-			cmd.Printf("PASS: %s/%s\n", res.Filename, res.Name)
+		}
+		// TODO: hide this behind a flag
+		if uncovered := run.UncoveredRules(); coverage && len(uncovered) > 0 {
+			cmd.Printf("UNCOVERED RULES:\n")
+			for _, rule := range uncovered {
+				cmd.Printf("  - %s\n", rule)
+			}
 		}
 	}
 }
 
-func writeJUnit(w io.Writer, results []ruletest.TestResult) error {
+func writeJUnit(w io.Writer, results []ruletest.TestRun) error {
 	suites := ruletest.AsJUnit(results)
 	if _, err := fmt.Fprint(w, xml.Header); err != nil {
 		return fmt.Errorf("failed to write XML header: %w", err)

--- a/cmd/dev/app/test/test.go
+++ b/cmd/dev/app/test/test.go
@@ -71,8 +71,7 @@ func CmdTest() *cobra.Command {
 			for _, run := range results {
 				for _, res := range run.Results {
 					if len(res.Failures)+len(res.Errors) > 0 {
-						finalErr = errors.New("one or more tests failed")
-						break
+						return errors.New("one or more tests failed")
 					}
 				}
 			}
@@ -109,7 +108,6 @@ func formatFailuresHuman(cmd *cobra.Command, results []ruletest.TestRun) {
 				cmd.Printf("PASS: %s/%s\n", res.Filename, res.Name)
 			}
 		}
-		// TODO: hide this behind a flag
 		if uncovered := run.UncoveredRules(); coverage && len(uncovered) > 0 {
 			cmd.Printf("UNCOVERED RULES:\n")
 			for _, rule := range uncovered {

--- a/pkg/ruletest/eval.go
+++ b/pkg/ruletest/eval.go
@@ -138,6 +138,9 @@ func (tr *testCaseRunner) builtinEval(
 
 	res, err := rte.Eval(ctx, entityProto, profileMap, paramsMap, &stubResultSink{})
 
+	// Record that this rule was evaluated, for coverage tracking.
+	tr.usedRules[ruleName] = struct{}{}
+
 	return formatEvalResult(res, err), nil
 }
 

--- a/pkg/ruletest/junit.go
+++ b/pkg/ruletest/junit.go
@@ -6,29 +6,49 @@ package ruletest
 import (
 	"encoding/xml"
 	"maps"
+	"path/filepath"
 	"slices"
 	"strings"
 )
 
 // JUnitTestSuites is the root element of a JUnit XML report.
 type JUnitTestSuites struct {
-	XMLName    xml.Name         `xml:"testsuites"`
+	XMLName  xml.Name `xml:"testsuites"`
+	Tests    int      `xml:"tests,attr,omitempty"`
+	Errors   int      `xml:"errors,attr,omitempty"`
+	Failures int      `xml:"failures,attr,omitempty"`
+	Skipped  int      `xml:"skipped,attr,omitempty"`
+	Disabled int      `xml:"disabled,attr,omitempty"`
+
 	TestSuites []JUnitTestSuite `xml:"testsuite"`
 }
 
 // JUnitTestSuite represents a single test suite in a JUnit XML report.
 type JUnitTestSuite struct {
-	Name      string          `xml:"name,attr"`
-	Tests     int             `xml:"tests,attr"`
-	Failures  int             `xml:"failures,attr"`
+	Name     string `xml:"name,attr"`
+	Tests    int    `xml:"tests,attr"`
+	Errors   int    `xml:"errors,attr"`
+	Failures int    `xml:"failures,attr"`
+	Skipped  int    `xml:"skipped,attr,omitempty"`
+	Disabled int    `xml:"disabled,attr,omitempty"`
+
+	File string `xml:"file,attr,omitempty"`
+
+	Properties *[]Property `xml:"properties>property,omitempty"`
+
 	TestCases []JUnitTestCase `xml:"testcase"`
 }
 
 // JUnitTestCase represents a single test case in a JUnit XML report.
 type JUnitTestCase struct {
-	Name      string        `xml:"name,attr"`
-	ClassName string        `xml:"classname,attr"`
+	Name      string `xml:"name,attr"`
+	ClassName string `xml:"classname,attr"`
+
 	Failure   *JUnitFailure `xml:"failure,omitempty"`
+	Error     *JUnitFailure `xml:"error,omitempty"`
+	Skipped   *JUnitFailure `xml:"skipped,omitempty"`
+	SystemOut *Output       `xml:"system-out,omitempty"`
+	SystemErr *Output       `xml:"system-err,omitempty"`
 }
 
 // JUnitFailure represents a failure within a test case.
@@ -38,43 +58,94 @@ type JUnitFailure struct {
 	Body    string `xml:",chardata"`
 }
 
+// Property represents a key-value pair in a JUnit XML report (used for coverage).
+type Property struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
+// Output represents the text output from a test case (currently not captured).
+type Output struct {
+	Body string `xml:",cdata"`
+}
+
 // AsJUnit converts test results into a JUnitTestSuites structure.
-func AsJUnit(results []TestResult) JUnitTestSuites {
+func AsJUnit(results []TestRun) JUnitTestSuites {
 	suitesMap := make(map[string]*JUnitTestSuite)
 
-	for _, res := range results {
-		suiteName := res.Filename
-		if _, ok := suitesMap[suiteName]; !ok {
-			suitesMap[suiteName] = &JUnitTestSuite{
-				Name: suiteName,
+	for _, run := range results {
+		for _, res := range run.Results {
+			suiteName := res.Filename
+			filePath := filepath.Join(run.BaseDir, suiteName)
+			if _, ok := suitesMap[filePath]; !ok {
+				suitesMap[filePath] = &JUnitTestSuite{
+					Name: suiteName,
+					File: filePath,
+					Properties: &[]Property{
+						{
+							Name:  "coverage.statements.pct",
+							Value: "100", // Claim 100% coverage if tests cover a rule at all
+						},
+					},
+				}
+			}
+
+			suite := suitesMap[filePath]
+			suite.Tests++
+
+			tc := JUnitTestCase{
+				Name:      res.Name,
+				ClassName: suiteName,
+			}
+
+			if len(res.Failures) > 0 {
+				suite.Failures++
+				tc.Failure = &JUnitFailure{
+					Message: "Test failed",
+					Body:    strings.Join(res.Failures, "\n"),
+				}
+			}
+			if len(res.Errors) > 0 {
+				suite.Errors++
+				tc.Error = &JUnitFailure{
+					Message: "Test error",
+					Body:    strings.Join(res.Errors, "\n"),
+				}
+			}
+
+			suite.TestCases = append(suite.TestCases, tc)
+		}
+		if len(run.UncoveredRules()) > 0 {
+			suitesMap[run.BaseDir] = &JUnitTestSuite{
+				Name: run.BaseDir,
+				File: run.BaseDir,
+				Properties: &[]Property{
+					{
+						Name:  "coverage.statements.pct",
+						Value: "0",
+					},
+				},
+			}
+			suite := suitesMap[run.BaseDir]
+			for _, rule := range run.UncoveredRules() {
+				// Represent each uncovered rule as a test case with a failure
+				suite.TestCases = append(suite.TestCases, JUnitTestCase{
+					Name: rule,
+				})
 			}
 		}
-
-		suite := suitesMap[suiteName]
-		suite.Tests++
-
-		tc := JUnitTestCase{
-			Name:      res.Name,
-			ClassName: suiteName,
-		}
-
-		if len(res.Failures) > 0 {
-			suite.Failures++
-			tc.Failure = &JUnitFailure{
-				Message: "Test failed",
-				Body:    strings.Join(res.Failures, "\n"),
-			}
-		}
-
-		suite.TestCases = append(suite.TestCases, tc)
 	}
 
-	var suitesList []JUnitTestSuite
+	res := JUnitTestSuites{}
+
 	for _, suite := range slices.Collect(maps.Values(suitesMap)) {
-		suitesList = append(suitesList, *suite)
+		res.TestSuites = append(res.TestSuites, *suite)
+		res.Tests += suite.Tests
+		res.Failures += suite.Failures
+		res.Errors += suite.Errors
+		res.Skipped += suite.Skipped
+		res.Disabled += suite.Disabled
 	}
 
-	return JUnitTestSuites{
-		TestSuites: suitesList,
-	}
+	return res
 }

--- a/pkg/ruletest/junit.go
+++ b/pkg/ruletest/junit.go
@@ -4,6 +4,7 @@
 package ruletest
 
 import (
+	"cmp"
 	"encoding/xml"
 	"maps"
 	"path/filepath"
@@ -138,7 +139,12 @@ func AsJUnit(results []TestRun) JUnitTestSuites {
 
 	res := JUnitTestSuites{}
 
-	for _, suite := range slices.Collect(maps.Values(suitesMap)) {
+	for _, suite := range slices.SortedFunc(
+		maps.Values(suitesMap),
+		func(a, b *JUnitTestSuite) int {
+			return cmp.Compare(a.File, b.File)
+		},
+	) {
 		res.TestSuites = append(res.TestSuites, *suite)
 		res.Tests += suite.Tests
 		res.Failures += suite.Failures

--- a/pkg/ruletest/junit.go
+++ b/pkg/ruletest/junit.go
@@ -6,6 +6,7 @@ package ruletest
 import (
 	"cmp"
 	"encoding/xml"
+	"fmt"
 	"maps"
 	"path/filepath"
 	"slices"
@@ -116,10 +117,16 @@ func AsJUnit(results []TestRun) JUnitTestSuites {
 
 			suite.TestCases = append(suite.TestCases, tc)
 		}
-		if len(run.UncoveredRules()) > 0 {
-			suitesMap[run.BaseDir] = &JUnitTestSuite{
-				Name: run.BaseDir,
-				File: run.BaseDir,
+		// See discussion in #6749: we want to record _something_ for ruletypes that don't
+		// have a corresponding test, but Tests > 0 is misleading.  The two options are:
+		// 1. Make up a suite and put each ruletype in as a testcase
+		// 2. Put each ruletype in its own suite
+		// We have chosen (2), as it makes it easier to understand the summary statistics like Test:0
+		for _, rule := range run.UncoveredRules() {
+			suite := &JUnitTestSuite{
+				// We use a different format from test suites to indicate ruletypes that don't have any tests.
+				Name: fmt.Sprintf("no-tests:%s", rule),
+				File: run.BaseDir + string(filepath.Separator), // TODO: do we want to keep and pass along a ruletype -> file map?
 				Properties: &[]Property{
 					{
 						Name:  "coverage.statements.pct",
@@ -127,13 +134,7 @@ func AsJUnit(results []TestRun) JUnitTestSuites {
 					},
 				},
 			}
-			suite := suitesMap[run.BaseDir]
-			for _, rule := range run.UncoveredRules() {
-				// Represent each uncovered rule as a test case with a failure
-				suite.TestCases = append(suite.TestCases, JUnitTestCase{
-					Name: rule,
-				})
-			}
+			suitesMap[suite.Name] = suite
 		}
 	}
 
@@ -142,7 +143,7 @@ func AsJUnit(results []TestRun) JUnitTestSuites {
 	for _, suite := range slices.SortedFunc(
 		maps.Values(suitesMap),
 		func(a, b *JUnitTestSuite) int {
-			return cmp.Compare(a.File, b.File)
+			return cmp.Or(cmp.Compare(a.File, b.File), cmp.Compare(a.Name, b.Name))
 		},
 	) {
 		res.TestSuites = append(res.TestSuites, *suite)

--- a/pkg/ruletest/junit_test.go
+++ b/pkg/ruletest/junit_test.go
@@ -45,17 +45,12 @@ func TestAsJUnit_PassingResultsMultipleSuites(t *testing.T) {
 			Tests: 4,
 			TestSuites: []JUnitTestSuite{
 				{
-					File: "bar",
-					Name: "bar",
+					File: "bar/",
+					Name: "no-tests:rule_d",
 					Properties: &[]Property{{
 						Name:  "coverage.statements.pct",
 						Value: "0",
 					}},
-					TestCases: []JUnitTestCase{
-						{
-							Name: "rule_d",
-						},
-					},
 				},
 				{
 					File:       "bar/file_b.star",

--- a/pkg/ruletest/junit_test.go
+++ b/pkg/ruletest/junit_test.go
@@ -45,6 +45,26 @@ func TestAsJUnit_PassingResultsMultipleSuites(t *testing.T) {
 			Tests: 4,
 			TestSuites: []JUnitTestSuite{
 				{
+					File: "bar",
+					Name: "bar",
+					Properties: &[]Property{{
+						Name:  "coverage.statements.pct",
+						Value: "0",
+					}},
+					TestCases: []JUnitTestCase{
+						{
+							Name: "rule_d",
+						},
+					},
+				},
+				{
+					File:       "bar/file_b.star",
+					Name:       "file_b.star",
+					Tests:      1,
+					Properties: &coverage100,
+					TestCases:  []JUnitTestCase{{Name: "test_one", ClassName: "file_b.star"}},
+				},
+				{
 					File:       "foo/file_a.star",
 					Name:       "file_a.star",
 					Tests:      2,
@@ -60,26 +80,6 @@ func TestAsJUnit_PassingResultsMultipleSuites(t *testing.T) {
 					Tests:      1,
 					Properties: &coverage100,
 					TestCases:  []JUnitTestCase{{Name: "test_three", ClassName: "file_b.star"}},
-				},
-				{
-					File:       "bar/file_b.star",
-					Name:       "file_b.star",
-					Tests:      1,
-					Properties: &coverage100,
-					TestCases:  []JUnitTestCase{{Name: "test_one", ClassName: "file_b.star"}},
-				},
-				{
-					File: "bar",
-					Name: "bar",
-					Properties: &[]Property{{
-						Name:  "coverage.statements.pct",
-						Value: "0",
-					}},
-					TestCases: []JUnitTestCase{
-						{
-							Name: "rule_d",
-						},
-					},
 				},
 			},
 		},
@@ -103,6 +103,19 @@ func TestAsJUnit_PassingResultsMultipleSuites(t *testing.T) {
 			Errors:   1,
 			TestSuites: []JUnitTestSuite{
 				{
+					File:       "suite/other.star",
+					Name:       "other.star",
+					Tests:      1,
+					Errors:     1,
+					Properties: &coverage100,
+					TestCases: []JUnitTestCase{
+						{
+							Name: "test_other", ClassName: "other.star",
+							Error: &JUnitFailure{Message: "Test error", Body: "err4"},
+						},
+					},
+				},
+				{
 					File:       "suite/suite.star",
 					Name:       "suite.star",
 					Tests:      3,
@@ -118,19 +131,6 @@ func TestAsJUnit_PassingResultsMultipleSuites(t *testing.T) {
 							Failure: &JUnitFailure{Message: "Test failed", Body: "err3"},
 						},
 						{Name: "test_pass", ClassName: "suite.star"},
-					},
-				},
-				{
-					File:       "suite/other.star",
-					Name:       "other.star",
-					Tests:      1,
-					Errors:     1,
-					Properties: &coverage100,
-					TestCases: []JUnitTestCase{
-						{
-							Name: "test_other", ClassName: "other.star",
-							Error: &JUnitFailure{Message: "Test error", Body: "err4"},
-						},
 					},
 				},
 			},

--- a/pkg/ruletest/junit_test.go
+++ b/pkg/ruletest/junit_test.go
@@ -5,90 +5,150 @@ package ruletest
 
 import (
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestAsJUnit_PassingResultsMultipleSuites(t *testing.T) {
 	t.Parallel()
-	results := []TestResult{
-		{Filename: "file_a.star", Name: "test_one"},
-		{Filename: "file_a.star", Name: "test_two"},
-		{Filename: "file_b.star", Name: "test_three"},
-	}
 
-	suites := AsJUnit(results)
+	coverage100 := []Property{{
+		Name:  "coverage.statements.pct",
+		Value: "100",
+	}}
 
-	if len(suites.TestSuites) != 2 {
-		t.Fatalf("expected 2 suites, got %d", len(suites.TestSuites))
-	}
+	tests := []struct {
+		name     string
+		results  []TestRun
+		expected JUnitTestSuites
+	}{{
+		name: "passing results multiple suites",
+		results: []TestRun{
+			{
+				BaseDir:     "foo",
+				LoadedRules: []string{"rule_a", "rule_b"},
+				Results: []TestResult{
+					{Filename: "file_a.star", Name: "test_one", EvaluatedRules: map[string]struct{}{"rule_a": {}}},
+					{Filename: "file_a.star", Name: "test_two", EvaluatedRules: map[string]struct{}{"rule_a": {}}},
+					{Filename: "file_b.star", Name: "test_three", EvaluatedRules: map[string]struct{}{"rule_b": {}}},
+				},
+			},
+			{
+				BaseDir:     "bar",
+				LoadedRules: []string{"rule_c", "rule_d"},
+				Results: []TestResult{
+					{Filename: "file_b.star", Name: "test_one", EvaluatedRules: map[string]struct{}{"rule_c": {}}},
+				},
+			},
+		},
+		expected: JUnitTestSuites{
+			Tests: 4,
+			TestSuites: []JUnitTestSuite{
+				{
+					File:       "foo/file_a.star",
+					Name:       "file_a.star",
+					Tests:      2,
+					Properties: &coverage100,
+					TestCases: []JUnitTestCase{
+						{Name: "test_one", ClassName: "file_a.star"},
+						{Name: "test_two", ClassName: "file_a.star"},
+					},
+				},
+				{
+					File:       "foo/file_b.star",
+					Name:       "file_b.star",
+					Tests:      1,
+					Properties: &coverage100,
+					TestCases:  []JUnitTestCase{{Name: "test_three", ClassName: "file_b.star"}},
+				},
+				{
+					File:       "bar/file_b.star",
+					Name:       "file_b.star",
+					Tests:      1,
+					Properties: &coverage100,
+					TestCases:  []JUnitTestCase{{Name: "test_one", ClassName: "file_b.star"}},
+				},
+				{
+					File: "bar",
+					Name: "bar",
+					Properties: &[]Property{{
+						Name:  "coverage.statements.pct",
+						Value: "0",
+					}},
+					TestCases: []JUnitTestCase{
+						{
+							Name: "rule_d",
+						},
+					},
+				},
+			},
+		},
+	}, {
+		name: "failure aggregation",
+		results: []TestRun{
+			{
+				BaseDir:     "suite",
+				LoadedRules: []string{},
+				Results: []TestResult{
+					{Filename: "suite.star", Name: "test_fail_one", Failures: []string{"err1", "err2"}},
+					{Filename: "suite.star", Name: "test_fail_two", Failures: []string{"err3"}},
+					{Filename: "suite.star", Name: "test_pass"},
+					{Filename: "other.star", Name: "test_other", Errors: []string{"err4"}},
+				},
+			},
+		},
+		expected: JUnitTestSuites{
+			Tests:    4,
+			Failures: 2,
+			Errors:   1,
+			TestSuites: []JUnitTestSuite{
+				{
+					File:       "suite/suite.star",
+					Name:       "suite.star",
+					Tests:      3,
+					Failures:   2,
+					Properties: &coverage100,
+					TestCases: []JUnitTestCase{
+						{
+							Name: "test_fail_one", ClassName: "suite.star",
+							Failure: &JUnitFailure{Message: "Test failed", Body: "err1\nerr2"},
+						},
+						{
+							Name: "test_fail_two", ClassName: "suite.star",
+							Failure: &JUnitFailure{Message: "Test failed", Body: "err3"},
+						},
+						{Name: "test_pass", ClassName: "suite.star"},
+					},
+				},
+				{
+					File:       "suite/other.star",
+					Name:       "other.star",
+					Tests:      1,
+					Errors:     1,
+					Properties: &coverage100,
+					TestCases: []JUnitTestCase{
+						{
+							Name: "test_other", ClassName: "other.star",
+							Error: &JUnitFailure{Message: "Test error", Body: "err4"},
+						},
+					},
+				},
+			},
+		},
+	}, {
+		name:     "empty input",
+		results:  nil,
+		expected: JUnitTestSuites{},
+	}}
 
-	suiteMap := make(map[string]JUnitTestSuite)
-	for _, s := range suites.TestSuites {
-		suiteMap[s.Name] = s
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			suites := AsJUnit(tt.results)
 
-	a := suiteMap["file_a.star"]
-	if a.Tests != 2 {
-		t.Errorf("file_a.star: expected 2 tests, got %d", a.Tests)
-	}
-	if a.Failures != 0 {
-		t.Errorf("file_a.star: expected 0 failures, got %d", a.Failures)
-	}
-
-	b := suiteMap["file_b.star"]
-	if b.Tests != 1 {
-		t.Errorf("file_b.star: expected 1 test, got %d", b.Tests)
-	}
-	if b.Failures != 0 {
-		t.Errorf("file_b.star: expected 0 failures, got %d", b.Failures)
-	}
-}
-
-func TestAsJUnit_FailuresAggregated(t *testing.T) {
-	t.Parallel()
-	results := []TestResult{
-		{Filename: "suite.star", Name: "test_fail_one", Failures: []string{"err1", "err2"}},
-		{Filename: "suite.star", Name: "test_fail_two", Failures: []string{"err3"}},
-		{Filename: "suite.star", Name: "test_pass"},
-	}
-
-	suites := AsJUnit(results)
-
-	if len(suites.TestSuites) != 1 {
-		t.Fatalf("expected 1 suite, got %d", len(suites.TestSuites))
-	}
-
-	suite := suites.TestSuites[0]
-	if suite.Tests != 3 {
-		t.Errorf("expected 3 tests, got %d", suite.Tests)
-	}
-	if suite.Failures != 2 {
-		t.Errorf("expected 2 failures, got %d", suite.Failures)
-	}
-
-	tcMap := make(map[string]JUnitTestCase)
-	for _, tc := range suite.TestCases {
-		tcMap[tc.Name] = tc
-	}
-
-	failOne := tcMap["test_fail_one"]
-	if failOne.Failure == nil {
-		t.Fatal("test_fail_one: expected a failure")
-	}
-	if failOne.Failure.Body != "err1\nerr2" {
-		t.Errorf("test_fail_one: expected joined failures, got %q", failOne.Failure.Body)
-	}
-
-	pass := tcMap["test_pass"]
-	if pass.Failure != nil {
-		t.Error("test_pass: expected no failure")
-	}
-}
-
-func TestAsJUnit_EmptyInput(t *testing.T) {
-	t.Parallel()
-	suites := AsJUnit(nil)
-
-	if len(suites.TestSuites) != 0 {
-		t.Errorf("expected 0 suites, got %d", len(suites.TestSuites))
+			if diff := cmp.Diff(tt.expected, suites); diff != "" {
+				t.Errorf("mismatch (-expected +got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/pkg/ruletest/runner.go
+++ b/pkg/ruletest/runner.go
@@ -79,11 +79,6 @@ func (tr *testCaseRunner) Error(args ...any) {
 	tr.failures = append(tr.failures, fmt.Sprint(args...))
 }
 
-// UsedRules returns a set of rule names that were evaluated during the test case execution.
-func (tr *testCaseRunner) UsedRules() map[string]struct{} {
-	return maps.Clone(tr.usedRules)
-}
-
 // TestResult holds the outcome of a single Starlark test function.
 type TestResult struct {
 	Filename string
@@ -213,7 +208,7 @@ func (r *Runner) runOneTest(
 	}
 
 	result.Failures = append(result.Failures, tr.failures...)
-	result.EvaluatedRules = tr.UsedRules()
+	result.EvaluatedRules = maps.Clone(tr.usedRules)
 
 	return result
 }

--- a/pkg/ruletest/runner.go
+++ b/pkg/ruletest/runner.go
@@ -108,6 +108,7 @@ func (tr *TestResult) Output() string {
 	return tr.printOutput.String()
 }
 
+// TestRun represents a run of all the tests in a given directory.
 type TestRun struct {
 	// BaseDir is the directory from which the test run was initiated.
 	BaseDir string

--- a/pkg/ruletest/runner.go
+++ b/pkg/ruletest/runner.go
@@ -91,8 +91,7 @@ type TestResult struct {
 	Failures []string
 	Errors   []string
 
-	// printOutput contains the output of any `print` statements executed during the test.
-	printOutput strings.Builder
+	// TODO: collect print output from Rego print() and Starlark (print?)
 
 	// EvaluatedRules is a set of rule names that were evaluated during the test.
 	EvaluatedRules map[string]struct{}
@@ -101,11 +100,6 @@ type TestResult struct {
 // Passed returns true if the test had no failures.
 func (tr *TestResult) Passed() bool {
 	return len(tr.Failures) == 0 && len(tr.Errors) == 0
-}
-
-// Output returns the captured output of any `print` statements executed during the test.
-func (tr *TestResult) Output() string {
-	return tr.printOutput.String()
 }
 
 // TestRun represents a run of all the tests in a given directory.

--- a/pkg/ruletest/runner.go
+++ b/pkg/ruletest/runner.go
@@ -35,6 +35,7 @@ type testCaseRunner struct {
 	predeclared starlark.StringDict
 	failures    []string
 	ruleTypes   map[string]*minderv1.RuleType
+	usedRules   map[string]struct{}
 }
 
 func (r *Runner) newTestCaseRunner(
@@ -48,6 +49,7 @@ func (r *Runner) newTestCaseRunner(
 		baseDir:     baseDir,
 		predeclared: starlark.StringDict{},
 		ruleTypes:   ruleTypes,
+		usedRules:   make(map[string]struct{}),
 	}
 	tr.thread = &starlark.Thread{
 		Name:  name,
@@ -72,8 +74,14 @@ func (tr *testCaseRunner) runFile(filename string, src any) (starlark.StringDict
 	return starlark.ExecFileOptions(&syntax.FileOptions{}, tr.thread, filename, src, tr.predeclared)
 }
 
+// Error is called by the starlarktest.Reporter interface when a test case fails.
 func (tr *testCaseRunner) Error(args ...any) {
 	tr.failures = append(tr.failures, fmt.Sprint(args...))
+}
+
+// UsedRules returns a set of rule names that were evaluated during the test case execution.
+func (tr *testCaseRunner) UsedRules() map[string]struct{} {
+	return maps.Clone(tr.usedRules)
 }
 
 // TestResult holds the outcome of a single Starlark test function.
@@ -81,11 +89,44 @@ type TestResult struct {
 	Filename string
 	Name     string
 	Failures []string
+	Errors   []string
+
+	// printOutput contains the output of any `print` statements executed during the test.
+	printOutput strings.Builder
+
+	// EvaluatedRules is a set of rule names that were evaluated during the test.
+	EvaluatedRules map[string]struct{}
 }
 
 // Passed returns true if the test had no failures.
 func (tr *TestResult) Passed() bool {
-	return len(tr.Failures) == 0
+	return len(tr.Failures) == 0 && len(tr.Errors) == 0
+}
+
+// Output returns the captured output of any `print` statements executed during the test.
+func (tr *TestResult) Output() string {
+	return tr.printOutput.String()
+}
+
+type TestRun struct {
+	// BaseDir is the directory from which the test run was initiated.
+	BaseDir string
+	// LoadedRules is a list of rule names that were loaded from disk for the run.
+	LoadedRules []string
+	// Results is a list of test results for each test function executed.
+	Results []TestResult
+}
+
+// UncoveredRules returns a list of rule names that were loaded but not evaluated during the test run.
+func (tr *TestRun) UncoveredRules() []string {
+	uncovered := slices.Clone(tr.LoadedRules)
+	for _, res := range tr.Results {
+		uncovered = slices.DeleteFunc(uncovered, func(rule string) bool {
+			_, ok := res.EvaluatedRules[rule]
+			return ok
+		})
+	}
+	return uncovered
 }
 
 // Runner loads and executes Starlark test files.
@@ -166,16 +207,18 @@ func (r *Runner) runOneTest(
 	tr := r.newTestCaseRunner(name, fileSystem, baseDir, ruleTypes)
 	result := TestResult{Name: name}
 
+	// TODO: capture output from print statements in Starlark and Rego
 	_, err := starlark.Call(tr.thread, fn, nil, nil)
 	if err != nil {
 		if evalErr, ok := errors.AsType[*starlark.EvalError](err); ok {
-			result.Failures = append(result.Failures, evalErr.Backtrace())
+			result.Errors = append(result.Errors, evalErr.Backtrace())
 		} else {
-			result.Failures = append(result.Failures, err.Error())
+			result.Errors = append(result.Errors, err.Error())
 		}
 	}
 
 	result.Failures = append(result.Failures, tr.failures...)
+	result.EvaluatedRules = tr.UsedRules()
 
 	return result
 }
@@ -243,7 +286,7 @@ func loadSingleRule(path string) (*minderv1.RuleType, error) {
 // files recursively. Tests are grouped by their immediate directory, and any
 // *.yaml rules in that same directory are loaded and made available to the tests.
 // It collects errors instead of returning early on the first error.
-func (r *Runner) RunPaths(paths []string) ([]TestResult, error) {
+func (r *Runner) RunPaths(paths []string) ([]TestRun, error) {
 	expanded, err := util.ExpandFileArgs(paths...)
 	if err != nil {
 		return nil, fmt.Errorf("expanding paths: %w", err)
@@ -262,7 +305,7 @@ func (r *Runner) RunPaths(paths []string) ([]TestResult, error) {
 		}
 	}
 
-	var allResults []TestResult
+	var runs []TestRun
 	var errs []error
 
 	// Ensure deterministic execution order by sorting directories
@@ -278,14 +321,21 @@ func (r *Runner) RunPaths(paths []string) ([]TestResult, error) {
 			continue
 		}
 
+		run := TestRun{
+			BaseDir:     dir,
+			LoadedRules: slices.Sorted(maps.Keys(ruleTypes)),
+		}
+
 		for _, file := range files {
 			res, err := r.RunFile(file, nil, ruleTypes)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("error running file %s: %w", file, err))
 				continue
 			}
-			allResults = append(allResults, res...)
+			run.Results = append(run.Results, res...)
 		}
+		runs = append(runs, run)
 	}
-	return allResults, errors.Join(errs...)
+
+	return runs, errors.Join(errs...)
 }

--- a/pkg/ruletest/runner_test.go
+++ b/pkg/ruletest/runner_test.go
@@ -29,20 +29,21 @@ func testDir(t *testing.T, r *Runner, dir string) {
 		return
 	}
 
-	for _, result := range results {
-		result := result
-		name := result.Filename + "/" + result.Name
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			if strings.HasPrefix(result.Name, "test_fail_") {
-				if result.Passed() {
-					t.Errorf("expected test %s to fail, but it passed", result.Name)
+	for _, run := range results {
+		for _, result := range run.Results {
+			name := result.Filename + "/" + result.Name
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				if strings.HasPrefix(result.Name, "test_fail_") {
+					if result.Passed() {
+						t.Errorf("expected test %s to fail, but it passed", result.Name)
+					}
+					return
 				}
-				return
-			}
-			for _, msg := range result.Failures {
-				t.Error(msg)
-			}
-		})
+				for _, msg := range result.Failures {
+					t.Error(msg)
+				}
+			})
+		}
 	}
 }

--- a/pkg/ruletest/runner_test.go
+++ b/pkg/ruletest/runner_test.go
@@ -43,6 +43,9 @@ func testDir(t *testing.T, r *Runner, dir string) {
 				for _, msg := range result.Failures {
 					t.Error(msg)
 				}
+				for _, msg := range result.Errors {
+					t.Error(msg)
+				}
 			})
 		}
 	}


### PR DESCRIPTION
# Summary

Tracks which rules in a directory were executed by `mindev test`, and includes a report of uncovered rules in the JUnit XML as well as in the text output.

For JUnit output, uncovered rules are reported in a new TestSuite that includes the rule names along with a coverage percentage of 0% for that TestSuite.  Existing TestSuites are marked as 100% coverage.

# Testing

Manual testing and added unit tests, particularly for JUnit output.
