### PR TITLE
fix(gitlab): paginate project listing

### DIFF
--- a/internal/providers/gitlab/gitlab_rest.go
+++ b/internal/providers/gitlab/gitlab_rest.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	provifv1 "github.com/mindersec/minder/pkg/providers/v1"
 )
@@ -103,6 +104,91 @@ func glRESTGet[T any](ctx context.Context, cli genericRESTClient, path string, o
 	}
 
 	return nil
+}
+
+const (
+	// glPerPage is the page size requested from collection endpoints.
+	// 100 is the maximum GitLab allows.
+	glPerPage = 100
+
+	// glNextPageHeader is the response header GitLab uses to point at the
+	// next page of an offset-paginated collection. It is empty on the
+	// last page.
+	glNextPageHeader = "X-Next-Page"
+)
+
+// glRESTGetPaginated retrieves every page of a GitLab collection endpoint
+// and appends the items to out. GitLab caps responses at per_page items
+// (20 by default), so collection endpoints have to follow the X-Next-Page
+// response header to retrieve the full result set.
+func glRESTGetPaginated[T any](ctx context.Context, cli genericRESTClient, path string, out *[]T) error {
+	for page := "1"; page != ""; {
+		items, nextPage, err := glRESTGetPage[T](ctx, cli, path, page)
+		if err != nil {
+			return err
+		}
+		*out = append(*out, items...)
+
+		// An empty page means there is nothing left to fetch regardless
+		// of what the header says, which also guards against a server
+		// that keeps reporting a next page.
+		if len(items) == 0 {
+			break
+		}
+		page = nextPage
+	}
+
+	return nil
+}
+
+// glRESTGetPage retrieves a single page of a GitLab collection endpoint and
+// returns the items along with the next page reported by the server.
+func glRESTGetPage[T any](ctx context.Context, cli genericRESTClient, path, page string) ([]T, string, error) {
+	pagedPath, err := pathWithPagination(path, page)
+	if err != nil {
+		return nil, "", err
+	}
+
+	req, err := cli.NewRequest(http.MethodGet, pagedPath, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := cli.Do(ctx, req)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get resource '%s': %w", pagedPath, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, "", provifv1.ErrEntityNotFound
+		}
+		return nil, "", fmt.Errorf("failed to get resource '%s': %s", pagedPath, resp.Status)
+	}
+
+	var items []T
+	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+		return nil, "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return items, resp.Header.Get(glNextPageHeader), nil
+}
+
+// pathWithPagination sets the page and per_page query parameters on path,
+// preserving any query parameters it already carries.
+func pathWithPagination(path, page string) (string, error) {
+	u, err := url.Parse(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse path '%s': %w", path, err)
+	}
+
+	q := u.Query()
+	q.Set("page", page)
+	q.Set("per_page", strconv.Itoa(glPerPage))
+	u.RawQuery = q.Encode()
+
+	return u.String(), nil
 }
 
 func getParsedURL(endpoint, path string) (*url.URL, error) {

--- a/internal/providers/gitlab/gitlab_rest_test.go
+++ b/internal/providers/gitlab/gitlab_rest_test.go
@@ -6,6 +6,7 @@ package gitlab
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -18,6 +19,7 @@ import (
 	"github.com/mindersec/minder/internal/providers/credentials"
 	"github.com/mindersec/minder/internal/util/ptr"
 	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
+	provifv1 "github.com/mindersec/minder/pkg/providers/v1"
 )
 
 type mockGitlabClient struct {
@@ -354,4 +356,123 @@ func Test_getParsedURL(t *testing.T) {
 			assert.Equal(t, tt.want.Fragment, got.Fragment, "Expected fragment to be equal")
 		})
 	}
+}
+
+func Test_glRESTGetPaginated(t *testing.T) {
+	t.Parallel()
+
+	newPagingClient := func(ts *httptest.Server) *mockGitlabClient {
+		return &mockGitlabClient{
+			doFunc: func(_ context.Context, req *http.Request) (*http.Response, error) {
+				return ts.Client().Do(req)
+			},
+			newRequestFunc: func(method, requestUrl string, _ any) (*http.Request, error) {
+				return http.NewRequest(method, ts.URL+"/"+requestUrl, nil)
+			},
+		}
+	}
+
+	t.Run("follows X-Next-Page across pages", func(t *testing.T) {
+		t.Parallel()
+
+		var pages []string
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			q := r.URL.Query()
+			assert.Equal(t, "keep", q.Get("existing"), "existing query params must be preserved")
+			assert.Equal(t, "100", q.Get("per_page"))
+
+			page := q.Get("page")
+			pages = append(pages, page)
+			if page == "1" {
+				w.Header().Set("X-Next-Page", "2")
+				fmt.Fprint(w, `["a", "b"]`)
+				return
+			}
+			fmt.Fprint(w, `["c"]`)
+		}))
+		defer ts.Close()
+
+		var out []string
+		err := glRESTGetPaginated(context.Background(), newPagingClient(ts), "test?existing=keep", &out)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"a", "b", "c"}, out)
+		assert.Equal(t, []string{"1", "2"}, pages)
+	})
+
+	t.Run("single page without header", func(t *testing.T) {
+		t.Parallel()
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, `["only"]`)
+		}))
+		defer ts.Close()
+
+		var out []string
+		err := glRESTGetPaginated(context.Background(), newPagingClient(ts), "test", &out)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"only"}, out)
+	})
+
+	t.Run("empty collection", func(t *testing.T) {
+		t.Parallel()
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, `[]`)
+		}))
+		defer ts.Close()
+
+		var out []string
+		err := glRESTGetPaginated(context.Background(), newPagingClient(ts), "test", &out)
+		require.NoError(t, err)
+		assert.Empty(t, out)
+	})
+
+	t.Run("stops when the server keeps reporting a next page with no items", func(t *testing.T) {
+		t.Parallel()
+
+		var requests int
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			requests++
+			w.Header().Set("X-Next-Page", "2")
+			fmt.Fprint(w, `[]`)
+		}))
+		defer ts.Close()
+
+		var out []string
+		err := glRESTGetPaginated(context.Background(), newPagingClient(ts), "test", &out)
+		require.NoError(t, err)
+		assert.Empty(t, out)
+		assert.Equal(t, 1, requests)
+	})
+
+	t.Run("404 maps to ErrEntityNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer ts.Close()
+
+		var out []string
+		err := glRESTGetPaginated(context.Background(), newPagingClient(ts), "test", &out)
+		require.ErrorIs(t, err, provifv1.ErrEntityNotFound)
+	})
+
+	t.Run("error on a later page fails the whole listing", func(t *testing.T) {
+		t.Parallel()
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("page") == "1" {
+				w.Header().Set("X-Next-Page", "2")
+				fmt.Fprint(w, `["a"]`)
+				return
+			}
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer ts.Close()
+
+		var out []string
+		err := glRESTGetPaginated(context.Background(), newPagingClient(ts), "test", &out)
+		require.Error(t, err)
+	})
 }

--- a/internal/providers/gitlab/repo_lister.go
+++ b/internal/providers/gitlab/repo_lister.go
@@ -23,7 +23,7 @@ var minAccessLevelControl = 25 // "Security Manager"
 
 func (c *gitlabClient) ListAllRepositories(ctx context.Context) ([]*minderv1.Repository, error) {
 	managedProjects := []*gitlab.Project{}
-	if err := glRESTGet(ctx, c, fmt.Sprintf("projects?min_access_level=%d", minAccessLevelControl), &managedProjects); err != nil {
+	if err := glRESTGetPaginated(ctx, c, fmt.Sprintf("projects?min_access_level=%d", minAccessLevelControl), &managedProjects); err != nil {
 		return nil, fmt.Errorf("failed to get projects: %w", err)
 	}
 

--- a/internal/providers/gitlab/repo_lister_test.go
+++ b/internal/providers/gitlab/repo_lister_test.go
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gitlab
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListAllRepositoriesPaginates(t *testing.T) {
+	t.Parallel()
+
+	// Two pages of projects: the server reports a second page via the
+	// X-Next-Page header and returns different projects for each page.
+	pageBodies := map[string]string{
+		"1": `[
+			{"id": 1, "name": "one", "namespace": {"path": "group"}},
+			{"id": 2, "name": "two", "namespace": {"path": "group"}}
+		]`,
+		"2": `[
+			{"id": 3, "name": "three", "namespace": {"path": "group"}}
+		]`,
+	}
+
+	var requestedPages []string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		assert.Equal(t, "25", q.Get("min_access_level"), "query params from the caller must be preserved")
+		assert.Equal(t, "100", q.Get("per_page"), "pages should be requested at GitLab's maximum size")
+
+		page := q.Get("page")
+		requestedPages = append(requestedPages, page)
+
+		body, ok := pageBodies[page]
+		require.True(t, ok, "unexpected page requested: %q", page)
+
+		if page == "1" {
+			w.Header().Set("X-Next-Page", "2")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(body))
+		require.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	repos, err := newTestGitlabProvider(ts.URL).ListAllRepositories(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, repos, 3, "projects from every page should be returned")
+	assert.Equal(t, []string{"1", "2"}, requestedPages)
+
+	names := make([]string, 0, len(repos))
+	for _, r := range repos {
+		names = append(names, r.GetName())
+	}
+	assert.Equal(t, []string{"one", "two", "three"}, names)
+}
+
+func TestListAllRepositoriesSinglePage(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "1", r.URL.Query().Get("page"))
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[{"id": 1, "name": "solo", "namespace": {"path": "group"}}]`)
+	}))
+	defer ts.Close()
+
+	repos, err := newTestGitlabProvider(ts.URL).ListAllRepositories(context.Background())
+	require.NoError(t, err)
+	require.Len(t, repos, 1)
+}


### PR DESCRIPTION
# Summary

ListAllRepositories made a single request to the projects endpoint, and GitLab caps unpaginated responses at 20 items, so accounts with more than 20 accessible projects silently lost the rest during repo registration.

This adds a paginated variant of the REST helper that follows the X-Next-Page response header at GitLab's maximum page size (100), preserves the caller's query parameters, and stops on an empty page so a misbehaving server can't cause an infinite loop. The 404 -> ErrEntityNotFound mapping matches the existing helper. The project listing now uses it; single-object callers of glRESTGet are unchanged.

Fixes #6750

# Testing

- New tests for the helper: multi-page traversal (asserts page=1 then page=2 with per_page=100 and preserved query params), single page, empty collection, a server that keeps reporting a next page with no items, 404 mapping, and an error on a later page failing the whole listing.
- New ListAllRepositories tests drive the real client against a two-page httptest server and assert all three projects come back in
  order. Without the fix this test fails - the old code sends no page parameters and returns only the first page.
- The full internal/providers/gitlab package passes; go vet is clean.