### PR TITLE
Add Starlark JSON module

### DIFF
--- a/pkg/ruletest/runner.go
+++ b/pkg/ruletest/runner.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strings"
 
+	"go.starlark.net/lib/json"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarktest"
 	"go.starlark.net/syntax"
@@ -60,6 +61,7 @@ func (r *Runner) newTestCaseRunner(
 	tr.predeclared["txtar"] = starlark.NewBuiltin("txtar", builtinTxtar)
 	tr.predeclared["body"] = starlark.NewBuiltin("body", builtinBody)
 	tr.predeclared["code"] = starlark.NewBuiltin("code", builtinCode)
+	tr.predeclared["json"] = json.Module
 
 	for k, v := range r.assertMod {
 		tr.predeclared[k] = v

--- a/pkg/ruletest/testdata/eval.star
+++ b/pkg/ruletest/testdata/eval.star
@@ -51,3 +51,10 @@ def test_skip_eval_missing_provider_trait():
     )
     assert.eq(res["status"], "skip")
     assert.true(res["message"] != "")
+
+def test_json():
+    obj = {"key": "value", "list": [1, 2, None], "nested": [{"bool": True}]}
+    json_str = json.encode(obj)
+    assert.eq('{"key":"value","list":[1,2,null],"nested":[{"bool":true}]}', json_str)
+    got = json.decode(json_str)
+    assert.eq(obj, got)


### PR DESCRIPTION
# Summary

Adds JSON encoding and decoding tools to the `mindev test` Starlark runtime.  This can be handy for varying JSON API output during tests; building a `json.encode` method in Starlark is not fully feasible, as Starlark prevents recursion and other Turing-complete features to ensure predictable runtime.

# Testing

Added a test which performs JSON encoding and decoding.  Tested that `assert.eq("", json_str)` in the test fails, then replaced with the correct value.  Starlark seems to preserve dict key order for iteration.
