### PR TITLE
fix: apply repository filter in ListArtifacts

### DIFF
--- a/internal/controlplane/handlers_artifacts.go
+++ b/internal/controlplane/handlers_artifacts.go
@@ -292,7 +292,7 @@ func (filter *artifactListFilter) listArtifacts(
 	// Filter by repository if needed and convert to protobuf
 	results := []*pb.Artifact{}
 	for _, ent := range artifactEnts {
-		if len(allowedRepoIDs) > 0 {
+		if len(filter.repoSlugList) > 0 {
 			if !ent.OriginatedFrom.Valid {
 				continue
 			}

--- a/internal/controlplane/handlers_artifacts.go
+++ b/internal/controlplane/handlers_artifacts.go
@@ -267,18 +267,34 @@ func (filter *artifactListFilter) listArtifacts(
 		return nil, fmt.Errorf("failed to get artifact entities: %w", err)
 	}
 
+	// Resolve repo slugs to entity IDs once, before the loop.
+	allowedRepoIDs := make(map[uuid.UUID]struct{}, len(filter.repoSlubList))
+	for _, slug := range filter.repoSlubList {
+		repoEnt, err := filter.store.GetEntityByName(ctx, db.GetEntityByNameParams{
+			ProjectID:  projectID,
+			EntityType: db.EntitiesRepository,
+			Name:       slug,
+			ProviderID: provider.ID,
+		})
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				continue
+			}
+			return nil, fmt.Errorf("failed to look up repository %q: %w", slug, err)
+		}
+		allowedRepoIDs[repoEnt.ID] = struct{}{}
+	}
+
 	// Filter by repository if needed and convert to protobuf
 	results := []*pb.Artifact{}
 	for _, ent := range artifactEnts {
-		// Apply repository filter if specified
 		if len(filter.repoSlubList) > 0 {
-			// Check if artifact originates from one of the filtered repos
 			if !ent.OriginatedFrom.Valid {
 				continue
 			}
-			// We need to check if the originated_from repository matches the filter
-			// For now, skip filtering - this requires loading the parent repo
-			// TODO: Implement efficient repo filtering
+			if _, ok := allowedRepoIDs[ent.OriginatedFrom.UUID]; !ok {
+				continue
+			}
 		}
 
 		// The entity name is the artifact name directly

--- a/internal/controlplane/handlers_artifacts.go
+++ b/internal/controlplane/handlers_artifacts.go
@@ -201,7 +201,7 @@ const (
 type artifactListFilter struct {
 	store db.Store
 
-	repoSlubList []string
+	repoSlugList []string
 	source       artifactSource
 	filter       string
 }
@@ -222,11 +222,11 @@ func parseArtifactListFrom(store db.Store, from string) (*artifactListFilter, er
 	source := parts[0]
 	filter := parts[1]
 
-	var repoSlubList []string
+	var repoSlugList []string
 
 	switch source {
 	case string(artifactSourceRepo):
-		repoSlubList = strings.Split(filter, ",")
+		repoSlugList = strings.Split(filter, ",")
 	default:
 		return nil, util.UserVisibleError(codes.InvalidArgument, "invalid filter source, only repository is supported")
 	}
@@ -235,7 +235,7 @@ func parseArtifactListFrom(store db.Store, from string) (*artifactListFilter, er
 		store:        store,
 		source:       artifactSource(source),
 		filter:       filter,
-		repoSlubList: repoSlubList,
+		repoSlugList: repoSlugList,
 	}, nil
 }
 
@@ -268,8 +268,12 @@ func (filter *artifactListFilter) listArtifacts(
 	}
 
 	// Resolve repo slugs to entity IDs once, before the loop.
-	allowedRepoIDs := make(map[uuid.UUID]struct{}, len(filter.repoSlubList))
-	for _, slug := range filter.repoSlubList {
+	// repoSlugList contains GitHub repository slugs (owner/repo format).
+	// Artifacts are included only if their OriginatedFrom repo matches one of
+	// these slugs. This is a GitHub-specific concept; DockerHub and Quay.io
+	// providers do not populate OriginatedFrom in the same way.
+	allowedRepoIDs := make(map[uuid.UUID]struct{}, len(filter.repoSlugList))
+	for _, slug := range filter.repoSlugList {
 		repoEnt, err := filter.store.GetEntityByName(ctx, db.GetEntityByNameParams{
 			ProjectID:  projectID,
 			EntityType: db.EntitiesRepository,
@@ -288,7 +292,7 @@ func (filter *artifactListFilter) listArtifacts(
 	// Filter by repository if needed and convert to protobuf
 	results := []*pb.Artifact{}
 	for _, ent := range artifactEnts {
-		if len(filter.repoSlubList) > 0 {
+		if len(allowedRepoIDs) > 0 {
 			if !ent.OriginatedFrom.Valid {
 				continue
 			}

--- a/internal/controlplane/handlers_artifacts_test.go
+++ b/internal/controlplane/handlers_artifacts_test.go
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: Copyright 2024 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controlplane
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	mockdb "github.com/mindersec/minder/database/mock"
+	"github.com/mindersec/minder/internal/db"
+	"github.com/mindersec/minder/internal/engine/engcontext"
+	pb "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+func TestListArtifacts_RepoFilter(t *testing.T) {
+	t.Parallel()
+
+	projectID := uuid.New()
+	providerID := uuid.New()
+	providerName := "github"
+
+	repoAID := uuid.New()
+	repoBID := uuid.New()
+
+	artifactFromRepoA := db.EntityInstance{
+		ID:         uuid.New(),
+		EntityType: db.EntitiesArtifact,
+		Name:       "artifact-a",
+		ProjectID:  projectID,
+		ProviderID: providerID,
+		CreatedAt:  time.Now(),
+		OriginatedFrom: uuid.NullUUID{
+			UUID:  repoAID,
+			Valid: true,
+		},
+	}
+	artifactFromRepoB := db.EntityInstance{
+		ID:         uuid.New(),
+		EntityType: db.EntitiesArtifact,
+		Name:       "artifact-b",
+		ProjectID:  projectID,
+		ProviderID: providerID,
+		CreatedAt:  time.Now(),
+		OriginatedFrom: uuid.NullUUID{
+			UUID:  repoBID,
+			Valid: true,
+		},
+	}
+	artifactNoRepo := db.EntityInstance{
+		ID:             uuid.New(),
+		EntityType:     db.EntitiesArtifact,
+		Name:           "artifact-no-repo",
+		ProjectID:      projectID,
+		ProviderID:     providerID,
+		CreatedAt:      time.Now(),
+		OriginatedFrom: uuid.NullUUID{Valid: false},
+	}
+
+	allArtifacts := []db.EntityInstance{artifactFromRepoA, artifactFromRepoB, artifactNoRepo}
+
+	tests := []struct {
+		name          string
+		from          string
+		setupMocks    func(store *mockdb.MockStore)
+		wantArtifacts []string
+	}{
+		{
+			name: "no filter returns all artifacts",
+			from: "",
+			setupMocks: func(store *mockdb.MockStore) {
+				store.EXPECT().GetProviderByName(gomock.Any(), db.GetProviderByNameParams{
+					Name:     providerName,
+					Projects: []uuid.UUID{projectID},
+				}).Return(db.Provider{ID: providerID, Name: providerName}, nil)
+				store.EXPECT().GetEntitiesByType(gomock.Any(), db.GetEntitiesByTypeParams{
+					EntityType: db.EntitiesArtifact,
+					ProviderID: providerID,
+					Projects:   []uuid.UUID{projectID},
+				}).Return(allArtifacts, nil)
+			},
+			wantArtifacts: []string{"artifact-a", "artifact-b", "artifact-no-repo"},
+		},
+		{
+			name: "filter by repo-a returns only artifact-a",
+			from: "repository=repo-a",
+			setupMocks: func(store *mockdb.MockStore) {
+				store.EXPECT().GetProviderByName(gomock.Any(), db.GetProviderByNameParams{
+					Name:     providerName,
+					Projects: []uuid.UUID{projectID},
+				}).Return(db.Provider{ID: providerID, Name: providerName}, nil)
+				store.EXPECT().GetEntitiesByType(gomock.Any(), db.GetEntitiesByTypeParams{
+					EntityType: db.EntitiesArtifact,
+					ProviderID: providerID,
+					Projects:   []uuid.UUID{projectID},
+				}).Return(allArtifacts, nil)
+				store.EXPECT().GetEntityByName(gomock.Any(), db.GetEntityByNameParams{
+					ProjectID:  projectID,
+					EntityType: db.EntitiesRepository,
+					Name:       "repo-a",
+					ProviderID: providerID,
+				}).Return(db.EntityInstance{ID: repoAID}, nil)
+			},
+			wantArtifacts: []string{"artifact-a"},
+		},
+		{
+			name: "filter by unknown repo returns empty list",
+			from: "repository=repo-unknown",
+			setupMocks: func(store *mockdb.MockStore) {
+				store.EXPECT().GetProviderByName(gomock.Any(), db.GetProviderByNameParams{
+					Name:     providerName,
+					Projects: []uuid.UUID{projectID},
+				}).Return(db.Provider{ID: providerID, Name: providerName}, nil)
+				store.EXPECT().GetEntitiesByType(gomock.Any(), db.GetEntitiesByTypeParams{
+					EntityType: db.EntitiesArtifact,
+					ProviderID: providerID,
+					Projects:   []uuid.UUID{projectID},
+				}).Return(allArtifacts, nil)
+				store.EXPECT().GetEntityByName(gomock.Any(), db.GetEntityByNameParams{
+					ProjectID:  projectID,
+					EntityType: db.EntitiesRepository,
+					Name:       "repo-unknown",
+					ProviderID: providerID,
+				}).Return(db.EntityInstance{}, sql.ErrNoRows)
+			},
+			wantArtifacts: []string{},
+		},
+		{
+			name: "filter by repo-a,repo-b returns both artifacts",
+			from: "repository=repo-a,repo-b",
+			setupMocks: func(store *mockdb.MockStore) {
+				store.EXPECT().GetProviderByName(gomock.Any(), db.GetProviderByNameParams{
+					Name:     providerName,
+					Projects: []uuid.UUID{projectID},
+				}).Return(db.Provider{ID: providerID, Name: providerName}, nil)
+				store.EXPECT().GetEntitiesByType(gomock.Any(), db.GetEntitiesByTypeParams{
+					EntityType: db.EntitiesArtifact,
+					ProviderID: providerID,
+					Projects:   []uuid.UUID{projectID},
+				}).Return(allArtifacts, nil)
+				store.EXPECT().GetEntityByName(gomock.Any(), db.GetEntityByNameParams{
+					ProjectID:  projectID,
+					EntityType: db.EntitiesRepository,
+					Name:       "repo-a",
+					ProviderID: providerID,
+				}).Return(db.EntityInstance{ID: repoAID}, nil)
+				store.EXPECT().GetEntityByName(gomock.Any(), db.GetEntityByNameParams{
+					ProjectID:  projectID,
+					EntityType: db.EntitiesRepository,
+					Name:       "repo-b",
+					ProviderID: providerID,
+				}).Return(db.EntityInstance{ID: repoBID}, nil)
+			},
+			wantArtifacts: []string{"artifact-a", "artifact-b"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			store := mockdb.NewMockStore(ctrl)
+			tc.setupMocks(store)
+
+			server := &Server{store: store}
+
+			ctx := engcontext.WithEntityContext(context.Background(), &engcontext.EntityContext{
+				Project:  engcontext.Project{ID: projectID},
+				Provider: engcontext.Provider{Name: providerName},
+			})
+
+			resp, err := server.ListArtifacts(ctx, &pb.ListArtifactsRequest{From: tc.from})
+			require.NoError(t, err)
+
+			var names []string
+			for _, a := range resp.Results {
+				names = append(names, a.Name)
+			}
+			if tc.wantArtifacts == nil {
+				tc.wantArtifacts = []string{}
+			}
+			if len(tc.wantArtifacts) == 0 {
+				assert.Empty(t, names)
+			} else {
+				assert.ElementsMatch(t, tc.wantArtifacts, names)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `ListArtifacts` with `from="repository=<name>"` silently ignored the filter and returned artifacts from all repositories in the project
- The `repoSlubList` was parsed correctly but the loop only checked `OriginatedFrom.Valid` - no name comparison was ever made against the slug list
- Fix resolves each slug to a repo entity UUID upfront via `GetEntityByName`, then checks `OriginatedFrom.UUID` membership per artifact in O(1)

## Root cause

`internal/controlplane/handlers_artifacts.go` lines 274–281 had a TODO comment where the actual filtering logic should have been:

```go
if len(filter.repoSlubList) > 0 {
    if !ent.OriginatedFrom.Valid {
        continue
    }
    // TODO: Implement efficient repo filtering  ← no name check happened
}

Changes

- internal/controlplane/handlers_artifacts.go: resolve slugs to repo entity UUIDs before the artifact loop, then filter by set membership
- internal/controlplane/handlers_artifacts_test.go: table-driven tests covering no-filter, single repo, unknown repo, and multi-repo cases

Test plan

- [ ] No filter → all artifacts returned
- [ ] repository=repo-a → only artifacts whose parent is repo-a are returned
- [ ] repository=repo-unknown → empty list (unknown slug gracefully skipped)
- [ ] repository=repo-a,repo-b → artifacts from both repos returned, others excluded