### PR TITLE
Fix timing attack in GitLab webhook secret verification

### DIFF
--- a/internal/providers/gitlab/webhooksecret/whsecret.go
+++ b/internal/providers/gitlab/webhooksecret/whsecret.go
@@ -6,6 +6,7 @@ package webhooksecret
 
 import (
 	sum "crypto/sha512"
+	"crypto/subtle"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -41,5 +42,5 @@ func Verify(base string, uniq string, secret string) bool {
 		return false
 	}
 
-	return s == secret
+	return subtle.ConstantTimeCompare([]byte(s), []byte(secret)) == 1
 }


### PR DESCRIPTION
Replace non-constant-time string comparison with crypto/subtle ConstantTimeCompare. The previous s == secret short-circuits on the first mismatched byte, leaking timing information that allows an attacker to recover the 128-char static webhook token character-by-character via repeated requests with measured latency.

GitHub webhooks already use constant-time comparison via hmac.Equal; this brings GitLab to the same standard.

Fixes CWE-208 (Observable Timing Discrepancy).

# Summary

`Verify()` in `internal/providers/gitlab/webhooksecret/whsecret.go`
compared the generated secret against the incoming token using `==`,
which is not constant-time. The GitLab webhook token is a static
128-char hex string reused across all requests, making timing recovery
practical. Replaced with `subtle.ConstantTimeCompare` from the Go
standard library. No behaviour change for valid or invalid tokens.

Fixes #(related issue)

# Testing

Existing unit tests in `whsecret_test.go` pass unchanged — `Verify()`
returns true for correct secrets and false for incorrect ones in all
cases. Verified locally with `go test ./internal/providers/gitlab/webhooksecret/`.